### PR TITLE
Enhance attendance ranking with streaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1465,6 +1465,19 @@
       }
     }
 
+    function calculateStreak(dates) {
+      if (!dates || !dates.length) return 0;
+      const sorted = dates
+        .map(d => parseLocalDate(d))
+        .sort((a, b) => b - a);
+      let streak = 1;
+      for (let i = 1; i < sorted.length; i++) {
+        const diff = (sorted[i - 1] - sorted[i]) / (1000 * 60 * 60 * 24);
+        if (diff === 7) streak++; else break;
+      }
+      return streak;
+    }
+
     // ========== DATA LOADING ==========
     async function ensureUserProfile() {
       try {
@@ -2085,7 +2098,10 @@
           { data: userRankingData, error: userRankingError }
         ] = await Promise.all([
           supabase.from('semanas_cn').select('bar_ganador').eq('estado', 'finalizada').not('bar_ganador', 'is', null),
-          supabase.from('asistencias').select('user_id, usuarios!inner(nombre)').eq('confirmado', true)
+          supabase.from('asistencias')
+            .select('user_id, semana_id, usuarios!inner(nombre), semanas_cn!inner(fecha_martes, estado)')
+            .eq('confirmado', true)
+            .eq('semanas_cn.estado', 'finalizada')
         ]);
         
         // Process top bars from historical data
@@ -2126,15 +2142,19 @@
           userRankingData.forEach(record => {
             const userId = record.user_id;
             const userName = record.usuarios?.nombre || 'Usuario';
-            userStats[userId] = {
-              nombre: userName,
-              asistencias: (userStats[userId]?.asistencias || 0) + 1
-            };
+            if (!userStats[userId]) {
+              userStats[userId] = { nombre: userName, asistencias: 0, dates: [] };
+            }
+            userStats[userId].asistencias += 1;
+            if (record.semanas_cn?.fecha_martes) {
+              userStats[userId].dates.push(record.semanas_cn.fecha_martes);
+            }
           });
         }
         
         // Convert to array and sort
         const sortedUsers = Object.values(userStats)
+          .map(u => ({ ...u, streak: calculateStreak(u.dates) }))
           .sort((a, b) => b.asistencias - a.asistencias)
           .slice(0, 20);
         
@@ -2146,7 +2166,10 @@
             userRankingEl.innerHTML = sortedUsers.map((user, i) => `
               <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px 12px; background: rgba(255,255,255,0.05); border-radius: 6px; margin-bottom: 4px;">
                 <span style="font-weight: 500;">${i + 1}. ${user.nombre}</span>
-                <span style="background: rgba(255, 224, 102, 0.2); color: #ffe066; padding: 2px 8px; border-radius: 4px; font-size: 0.8rem;">${user.asistencias} CNs</span>
+                <span>
+                  <span style="background: rgba(255, 224, 102, 0.2); color: #ffe066; padding: 2px 8px; border-radius: 4px; font-size: 0.8rem;">${user.asistencias} CNs</span>
+                  <span style="background: rgba(255, 110, 80, 0.2); color: #ff6e50; padding: 2px 6px; border-radius: 4px; font-size: 0.8rem; margin-left: 4px;">🔥 ${user.streak}</span>
+                </span>
               </div>
             `).join('');
           }
@@ -2309,8 +2332,9 @@
             .order('fecha_martes', { ascending: false }),
           supabase
             .from('asistencias')
-            .select('user_id, usuarios!inner(nombre)')
+            .select('user_id, semana_id, usuarios!inner(nombre), semanas_cn!inner(fecha_martes, estado)')
             .eq('confirmado', true)
+            .eq('semanas_cn.estado', 'finalizada')
         ]);
 
         // ===== Top Bars =====
@@ -2348,14 +2372,18 @@
           userRankingData.forEach(record => {
             const userId = record.user_id;
             const userName = record.usuarios?.nombre || 'Usuario';
-            userStats[userId] = {
-              nombre: userName,
-              asistencias: (userStats[userId]?.asistencias || 0) + 1
-            };
+            if (!userStats[userId]) {
+              userStats[userId] = { nombre: userName, asistencias: 0, dates: [] };
+            }
+            userStats[userId].asistencias += 1;
+            if (record.semanas_cn?.fecha_martes) {
+              userStats[userId].dates.push(record.semanas_cn.fecha_martes);
+            }
           });
         }
 
         const sortedUsers = Object.values(userStats)
+          .map(u => ({ ...u, streak: calculateStreak(u.dates) }))
           .sort((a, b) => b.asistencias - a.asistencias)
           .slice(0, 20);
 
@@ -2367,7 +2395,10 @@
             userRankingEl.innerHTML = sortedUsers.map((user, index) => `
               <div class="d-flex justify-content-between align-items-center py-1">
                 <span>${index + 1}. ${user.nombre}</span>
-                <span class="badge bg-success rounded-pill">${user.asistencias} CNs</span>
+                <span>
+                  <span class="badge bg-success rounded-pill">${user.asistencias} CNs</span>
+                  <span class="badge bg-danger rounded-pill ms-1">🔥 ${user.streak}</span>
+                </span>
               </div>`).join('');
           }
         }


### PR DESCRIPTION
## Summary
- include week data in attendance queries and filter finalizadas
- calculate attendance streaks per user
- show streak badges in mobile and desktop rankings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fa7a3c9083239be8128bc1c8be6f