### PR TITLE
Adjust CN voting cutoff to 23:00

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ¿Dónde vamos a la CN hoy?
 
 * Los eventos de CN siempre se realizan los **martes**.
-* La votación queda abierta cada semana hasta el **martes a las 23:59**.
+* La votación queda abierta cada semana hasta el **martes a las 23:00**.
 * Los votos emitidos después de esa hora son ignorados por `vote.js`.
 
 ## Variables de Entorno

--- a/netlify/functions/vote.js
+++ b/netlify/functions/vote.js
@@ -54,9 +54,9 @@ exports.handler = async (event) => {
     try {
       const { place } = JSON.parse(event.body);
 
-      // Calcular la fecha límite de votación: martes a las 23:59 UTC
+      // Calcular la fecha límite de votación: martes a las 23:00 UTC
       const votingDeadline = new Date(weekStart);
-      votingDeadline.setUTCHours(23, 59, 59, 999);
+      votingDeadline.setUTCHours(23, 0, 0, 0);
 
       // Si ya pasó la fecha límite, rechazar el voto
       if (today > votingDeadline) {


### PR DESCRIPTION
## Summary
- update README to mention voting closes at 23:00 Tuesday
- set vote.js deadline to 23:00

## Testing
- `npm test` *(fails: no test specified)*
- `node` script verifying votes after 23:00 are rejected

------
https://chatgpt.com/codex/tasks/task_e_68497a5049308323bbe27ec44efb3314