### PR TITLE
Update streak order in ranking

### DIFF
--- a/index.html
+++ b/index.html
@@ -2177,8 +2177,8 @@
               <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px 12px; background: rgba(255,255,255,0.05); border-radius: 6px; margin-bottom: 4px;">
                 <span style="font-weight: 500;">${i + 1}. ${user.nombre}</span>
                 <span>
+                  ${user.streak > 0 ? `<span style="background: rgba(255, 110, 80, 0.2); color: #ff6e50; padding: 2px 6px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px;">🔥 ${user.streak}</span>` : ''}
                   <span style="background: rgba(255, 224, 102, 0.2); color: #ffe066; padding: 2px 8px; border-radius: 4px; font-size: 0.8rem;">${user.asistencias} CNs</span>
-                  ${user.streak > 0 ? `<span style="background: rgba(255, 110, 80, 0.2); color: #ff6e50; padding: 2px 6px; border-radius: 4px; font-size: 0.8rem; margin-left: 4px;">🔥 ${user.streak}</span>` : ''}
                 </span>
               </div>
             `).join('');
@@ -2410,8 +2410,8 @@
               <div class="d-flex justify-content-between align-items-center py-1">
                 <span>${index + 1}. ${user.nombre}</span>
                 <span>
+                  ${user.streak > 0 ? `<span class="badge bg-danger rounded-pill me-1">🔥 ${user.streak}</span>` : ''}
                   <span class="badge bg-success rounded-pill">${user.asistencias} CNs</span>
-                  ${user.streak > 0 ? `<span class="badge bg-danger rounded-pill ms-1">🔥 ${user.streak}</span>` : ''}
                 </span>
               </div>`).join('');
           }


### PR DESCRIPTION
## Summary
- show streak flame before total CNs so the ranking aligns better

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68497a80e5bc8323baf6eb284a45cdea