### PR TITLE
Share admin list between pages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="config.js"></script>
   <style>
     body {
       background: linear-gradient(135deg, #1a1a2e, #16213e);
@@ -222,10 +223,6 @@
     const supabase = window.supabase.createClient(supabaseUrl, supabaseKey);
 
     // ========== CONFIGURACIÓN DE ADMINS ==========
-    const ADMIN_EMAILS = [
-      'ahidalgod@gmail.com',    // Tu email de admin
-      'admin2@example.com'      // Agrega otros admins si quieres
-    ];
 
     let currentUser = null;
     let pendingAction = null;

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+// Global configuration
+const ADMIN_EMAILS = [
+  'ahidalgod@gmail.com',
+  'admin2@example.com'
+];

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="config.js"></script>
   <style>
     /* ========== GLOBAL STYLES ========== */
     * {
@@ -1243,7 +1244,7 @@
       const firstLetter = (currentUser.email || 'U').charAt(0).toUpperCase();
       
       // Check if user is admin
-      isAdmin = currentUser.email === 'ahidalgod@gmail.com'; 
+      isAdmin = ADMIN_EMAILS.includes(currentUser.email);
       
       // Show/hide admin tab based on admin status
       const adminTab = document.getElementById('desktop-admin-tab');


### PR DESCRIPTION
## Summary
- centralize admin email list in `config.js`
- load the new shared config file from `index.html` and `admin.html`
- reference `ADMIN_EMAILS` for admin checks in `index.html`

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68497cf76c648323b00dddf50e155e88