### PR TITLE
Add admin week edit controls

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -229,7 +229,6 @@
 
     let currentUser = null;
     let pendingAction = null;
-    let editingWeekId = null;
 
     // ========== INICIALIZACIÓN ==========
     async function init() {
@@ -649,76 +648,6 @@
       );
     }
 
-    async function openEditWeek(weekId) {
-      try {
-        const [weekRes, barsRes, usersRes, attendsRes] = await Promise.all([
-          supabase.from('semanas_cn').select('*').eq('id', weekId).single(),
-          supabase.from('bares').select('nombre').order('nombre'),
-          supabase.from('usuarios').select('id, nombre').order('nombre'),
-          supabase.from('asistencias').select('user_id').eq('semana_id', weekId).eq('confirmado', true)
-        ]);
-
-        if (weekRes.error) throw weekRes.error;
-        if (barsRes.error) throw barsRes.error;
-        if (usersRes.error) throw usersRes.error;
-        if (attendsRes.error) throw attendsRes.error;
-
-        editingWeekId = weekId;
-
-        const barSelect = document.getElementById('editWeekBar');
-        barSelect.innerHTML = (barsRes.data || []).map(b => `<option value="${b.nombre}">${b.nombre}</option>`).join('');
-        if (weekRes.data?.bar_ganador) {
-          barSelect.value = weekRes.data.bar_ganador;
-        }
-
-        const attendees = new Set((attendsRes.data || []).map(a => a.user_id));
-        const usersContainer = document.getElementById('editWeekUsers');
-        usersContainer.innerHTML = (usersRes.data || []).map(u => `
-          <div class="form-check">
-            <input class="form-check-input" type="checkbox" value="${u.id}" id="editUser-${u.id}" ${attendees.has(u.id) ? 'checked' : ''}>
-            <label class="form-check-label" for="editUser-${u.id}">${u.nombre}</label>
-          </div>
-        `).join('');
-
-        const modal = new bootstrap.Modal(document.getElementById('editWeekModal'));
-        modal.show();
-      } catch (error) {
-        showAlert('Error cargando datos de la semana: ' + error.message, 'danger');
-      }
-    }
-
-    async function saveWeekChanges() {
-      if (!editingWeekId) return;
-
-      const bar = document.getElementById('editWeekBar').value || null;
-      const selected = Array.from(document.querySelectorAll('#editWeekUsers input:checked')).map(el => el.value);
-      const total = selected.length;
-
-      try {
-        await supabase.from('semanas_cn').update({
-          bar_ganador: bar,
-          total_asistentes: total,
-          hubo_quorum: total >= 3
-        }).eq('id', editingWeekId);
-
-        await supabase.from('asistencias').delete().eq('semana_id', editingWeekId);
-
-        if (selected.length) {
-          const rows = selected.map(id => ({ user_id: id, semana_id: editingWeekId, confirmado: true }));
-          await supabase.from('asistencias').insert(rows);
-        }
-
-        const modal = bootstrap.Modal.getInstance(document.getElementById('editWeekModal'));
-        modal.hide();
-
-        showAlert('Semana actualizada exitosamente', 'success');
-        await loadDashboard();
-      } catch (error) {
-        showAlert('Error actualizando semana: ' + error.message, 'danger');
-      } finally {
-        editingWeekId = null;
-      }
-    }
 
     // ========== UTILIDADES ==========
     function confirmAction(message, action) {
@@ -739,7 +668,6 @@
       }
     });
 
-    document.getElementById('saveWeekChanges').addEventListener('click', saveWeekChanges);
 
     function showAlert(message, type = 'info') {
       const alertDiv = document.createElement('div');
@@ -782,7 +710,8 @@
     }, 30000);
 
     // Inicializar
-    init();
+  init();
   </script>
+  <script src="weekEdit.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -785,6 +785,14 @@
       font-weight: 700;
       color: #ffe066;
     }
+
+    .edit-week-btn {
+      margin-left: 8px;
+    }
+
+    @media (max-width: 768px) {
+      .edit-week-btn { display: none !important; }
+    }
   </style>
 </head>
 <body>
@@ -2336,7 +2344,7 @@
         ] = await Promise.all([
           supabase
             .from('semanas_cn')
-            .select('bar_ganador, fecha_martes')
+            .select('id, bar_ganador, fecha_martes')
             .eq('estado', 'finalizada')
             .not('bar_ganador', 'is', null)
             .order('fecha_martes', { ascending: false }),
@@ -2426,13 +2434,13 @@
             const lastVisits = {};
             weeksData.forEach(week => {
               if (week.bar_ganador && !lastVisits[week.bar_ganador]) {
-                lastVisits[week.bar_ganador] = week.fecha_martes;
+                lastVisits[week.bar_ganador] = { date: week.fecha_martes, id: week.id };
               }
             });
 
             const barsWithVisits = bars.map(bar => {
-              const lastVisit = lastVisits[bar.name];
-              return { name: bar.name, lastVisit };
+              const visit = lastVisits[bar.name];
+              return { name: bar.name, lastVisit: visit?.date, weekId: visit?.id };
             }).sort((a, b) => {
               if (!a.lastVisit && !b.lastVisit) return a.name.localeCompare(b.name);
               if (!a.lastVisit) return 1;
@@ -2457,6 +2465,7 @@
                 <div class="d-flex justify-content-between align-items-center py-1">
                   <span>${bar.name}</span>
                   <span class="${visitClass}">${visitText}</span>
+                  ${isAdmin && bar.weekId ? `<button class="btn btn-sm btn-outline-info edit-week-btn" onclick="openEditWeek(${bar.weekId})">Editar</button>` : ''}
                 </div>`;
             }).join('');
           }
@@ -2851,5 +2860,30 @@
     window.cancelBarEdit = cancelBarEdit;
     window.signOut = signOut;
   </script>
+  <div class="modal fade" id="editWeekModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content bg-dark text-light">
+        <div class="modal-header">
+          <h5 class="modal-title">Editar Semana</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="editWeekBar" class="form-label">Bar visitado</label>
+            <select id="editWeekBar" class="form-select"></select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Asistentes</label>
+            <div id="editWeekUsers" class="d-flex flex-wrap" style="gap: 10px; max-height: 300px; overflow-y: auto;"></div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="button" class="btn btn-primary" id="saveWeekChanges">Guardar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="weekEdit.js"></script>
 </body>
 </html>

--- a/weekEdit.js
+++ b/weekEdit.js
@@ -1,0 +1,97 @@
+let editingWeekId = null;
+
+async function openEditWeek(weekId) {
+  try {
+    const [weekRes, barsRes, usersRes, attendsRes] = await Promise.all([
+      supabase.from('semanas_cn').select('*').eq('id', weekId).single(),
+      supabase.from('bares').select('nombre').order('nombre'),
+      supabase.from('usuarios').select('id, nombre').order('nombre'),
+      supabase.from('asistencias').select('user_id').eq('semana_id', weekId).eq('confirmado', true)
+    ]);
+
+    if (weekRes.error) throw weekRes.error;
+    if (barsRes.error) throw barsRes.error;
+    if (usersRes.error) throw usersRes.error;
+    if (attendsRes.error) throw attendsRes.error;
+
+    editingWeekId = weekId;
+
+    const barSelect = document.getElementById('editWeekBar');
+    barSelect.innerHTML = (barsRes.data || []).map(b => `<option value="${b.nombre}">${b.nombre}</option>`).join('');
+    if (weekRes.data?.bar_ganador) {
+      barSelect.value = weekRes.data.bar_ganador;
+    }
+
+    const attendees = new Set((attendsRes.data || []).map(a => a.user_id));
+    const usersContainer = document.getElementById('editWeekUsers');
+    usersContainer.innerHTML = (usersRes.data || []).map(u => `
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" value="${u.id}" id="editUser-${u.id}" ${attendees.has(u.id) ? 'checked' : ''}>
+        <label class="form-check-label" for="editUser-${u.id}">${u.nombre}</label>
+      </div>
+    `).join('');
+
+    const modal = new bootstrap.Modal(document.getElementById('editWeekModal'));
+    modal.show();
+  } catch (error) {
+    if (window.showAlert) {
+      window.showAlert('Error cargando datos de la semana: ' + error.message, 'danger');
+    } else {
+      alert('Error cargando datos de la semana: ' + error.message);
+    }
+  }
+}
+
+async function saveWeekChanges() {
+  if (!editingWeekId) return;
+
+  const bar = document.getElementById('editWeekBar').value || null;
+  const selected = Array.from(document.querySelectorAll('#editWeekUsers input:checked')).map(el => el.value);
+  const total = selected.length;
+
+  try {
+    await supabase.from('semanas_cn').update({
+      bar_ganador: bar,
+      total_asistentes: total,
+      hubo_quorum: total >= 3
+    }).eq('id', editingWeekId);
+
+    await supabase.from('asistencias').delete().eq('semana_id', editingWeekId);
+
+    if (selected.length) {
+      const rows = selected.map(id => ({ user_id: id, semana_id: editingWeekId, confirmado: true }));
+      await supabase.from('asistencias').insert(rows);
+    }
+
+    const modal = bootstrap.Modal.getInstance(document.getElementById('editWeekModal'));
+    modal.hide();
+
+    if (window.showAlert) {
+      window.showAlert('Semana actualizada exitosamente', 'success');
+    } else {
+      alert('Semana actualizada exitosamente');
+    }
+
+    if (typeof loadDashboard === 'function') {
+      await loadDashboard();
+    } else if (typeof loadDesktopStats === 'function') {
+      await loadDesktopStats();
+      if (typeof loadVotingData === 'function') {
+        await loadVotingData();
+      }
+    }
+  } catch (error) {
+    if (window.showAlert) {
+      window.showAlert('Error actualizando semana: ' + error.message, 'danger');
+    } else {
+      alert('Error actualizando semana: ' + error.message);
+    }
+  } finally {
+    editingWeekId = null;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('saveWeekChanges');
+  if (btn) btn.addEventListener('click', saveWeekChanges);
+});


### PR DESCRIPTION
## Summary
- support editing weeks from the main page when user is admin
- refactor week editing logic to shared `weekEdit.js`
- load new script in admin and index pages
- show edit button beside last visit items for admins

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68497cf3adb08323bd41a62b44560393