### PR TITLE
Fix week editing with numeric user IDs

### DIFF
--- a/weekEdit.js
+++ b/weekEdit.js
@@ -46,7 +46,9 @@ async function saveWeekChanges() {
   if (!editingWeekId) return;
 
   const bar = document.getElementById('editWeekBar').value || null;
-  const selected = Array.from(document.querySelectorAll('#editWeekUsers input:checked')).map(el => el.value);
+  const selected = Array.from(
+    document.querySelectorAll('#editWeekUsers input:checked')
+  ).map(el => parseInt(el.value, 10));
   const total = selected.length;
 
   try {
@@ -68,7 +70,7 @@ async function saveWeekChanges() {
 
     if (selected.length) {
       const rows = selected.map((id) => ({
-        user_id: id,
+        user_id: parseInt(id, 10),
         semana_id: editingWeekId,
         confirmado: true,
       }));


### PR DESCRIPTION
## Summary
- ensure selected attendee IDs are converted to numbers
- store numeric user IDs when inserting asistencia rows

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684985b50c008323b8096f62b07fcdc3