### PR TITLE
Update admin to ensure profile exists

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -225,6 +225,7 @@
     // ========== CONFIGURACIÓN DE ADMINS ==========
 
     let currentUser = null;
+    let currentUserProfile = null;
     let pendingAction = null;
 
     // ========== INICIALIZACIÓN ==========
@@ -249,9 +250,11 @@
           return;
         }
 
+        await ensureUserProfile();
+
         document.getElementById('authCheck').style.display = 'none';
         document.getElementById('adminPanel').style.display = 'block';
-        
+
         await loadDashboard();
         
       } catch (error) {
@@ -491,6 +494,37 @@
 
       } catch (error) {
         console.error('Error cargando log de actividad:', error);
+      }
+    }
+
+    async function ensureUserProfile() {
+      try {
+        let { data, error } = await supabase
+          .from('usuarios')
+          .select('*')
+          .eq('id', currentUser.id)
+          .single();
+
+        if (error && error.code !== 'PGRST116') throw error;
+
+        if (!data) {
+          const { data: inserted, error: insertError } = await supabase
+            .from('usuarios')
+            .insert({
+              id: currentUser.id,
+              email: currentUser.email,
+              nombre: currentUser.user_metadata?.name || currentUser.email.split('@')[0],
+              avatar_url: currentUser.user_metadata?.avatar_url
+            })
+            .select()
+            .single();
+          if (insertError) throw insertError;
+          data = inserted;
+        }
+
+        currentUserProfile = data;
+      } catch (error) {
+        console.error('❌ Error en ensureUserProfile:', error);
       }
     }
 


### PR DESCRIPTION
## Summary
- replicate `ensureUserProfile` logic from `index.html` in `admin.html`
- create `currentUserProfile` state in admin
- call `ensureUserProfile()` after verifying admin email

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684985b60e048323928022870dc2b981