### PR TITLE
Add Jest test coverage for week editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "@supabase/supabase-js": "^2.39.3"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "Your Name",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "jest": "^30.0.0",
+    "jest-environment-jsdom": "^30.0.0"
+  }
 }

--- a/tests/weekEdit.test.js
+++ b/tests/weekEdit.test.js
@@ -1,0 +1,69 @@
+/** @jest-environment jsdom */
+const { saveWeekChanges, _setEditingWeekId, _getEditingWeekId } = require('../weekEdit');
+
+describe('saveWeekChanges', () => {
+  let updateEqMock, deleteEqMock, insertMock, hideMock;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <select id="editWeekBar"><option value="Bar1">Bar1</option></select>
+      <div id="editWeekUsers">
+        <input type="checkbox" value="u1" checked>
+        <input type="checkbox" value="u2">
+      </div>
+      <div id="editWeekModal"></div>
+    `;
+
+    hideMock = jest.fn();
+    global.bootstrap = {
+      Modal: {
+        getInstance: jest.fn(() => ({ hide: hideMock }))
+      }
+    };
+
+    updateEqMock = jest.fn().mockResolvedValue({ error: null });
+    const updateMock = jest.fn(() => ({ eq: updateEqMock }));
+    deleteEqMock = jest.fn().mockResolvedValue({ error: null });
+    const deleteMock = jest.fn(() => ({ eq: deleteEqMock }));
+    insertMock = jest.fn().mockResolvedValue({ error: null });
+
+    global.supabase = {
+      from: jest.fn((table) => {
+        if (table === 'semanas_cn') {
+          return { update: updateMock };
+        }
+        if (table === 'asistencias') {
+          return { delete: deleteMock, insert: insertMock };
+        }
+        return {};
+      })
+    };
+
+    global.showAlert = jest.fn();
+
+    _setEditingWeekId(1);
+  });
+
+  afterEach(() => {
+    delete global.supabase;
+    delete global.bootstrap;
+    delete global.showAlert;
+  });
+
+  test('updates week and attendees then resets editingWeekId', async () => {
+    await saveWeekChanges();
+
+    expect(global.supabase.from).toHaveBeenCalledWith('semanas_cn');
+    expect(updateEqMock).toHaveBeenCalledWith('id', 1);
+
+    expect(global.supabase.from).toHaveBeenCalledWith('asistencias');
+    expect(deleteEqMock).toHaveBeenCalledWith('semana_id', 1);
+
+    expect(insertMock).toHaveBeenCalledWith([
+      { user_id: 'u1', semana_id: 1, confirmado: true }
+    ]);
+
+    expect(hideMock).toHaveBeenCalled();
+    expect(_getEditingWeekId()).toBeNull();
+  });
+});

--- a/weekEdit.js
+++ b/weekEdit.js
@@ -112,3 +112,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('saveWeekChanges');
   if (btn) btn.addEventListener('click', saveWeekChanges);
 });
+
+// Export for testing in Node environments
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    openEditWeek,
+    saveWeekChanges,
+    _setEditingWeekId: (id) => { editingWeekId = id; },
+    _getEditingWeekId: () => editingWeekId,
+  };
+}


### PR DESCRIPTION
## Summary
- ignore node modules and lock file
- expose functions in `weekEdit.js` for testing
- configure Jest and jsdom
- add unit test for `saveWeekChanges`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498ccab4648323b4252b3ae4d5749a