### PR TITLE
Update vote IP logic and add tests

### DIFF
--- a/netlify/functions/vote.js
+++ b/netlify/functions/vote.js
@@ -15,7 +15,12 @@ const supabase = createClient(
 );
 
 exports.handler = async (event) => {
-  const ip = event.headers["client-ip"] || "unknown";
+  const ip =
+    event.headers["client-ip"] ||
+    event.headers["x-nf-client-connection-ip"] ||
+    (event.headers["x-forwarded-for"]
+      ? event.headers["x-forwarded-for"].split(",")[0].trim()
+      : "unknown");
   const today = new Date();
   const weekStart = new Date(today);
   // Calcular el martes anterior a las 00:00 como inicio de la semana

--- a/tests/vote.test.js
+++ b/tests/vote.test.js
@@ -1,0 +1,76 @@
+/** @jest-environment node */
+
+let supabaseMock;
+
+const path = require('path');
+const fs = require('fs');
+const vm = require('vm');
+
+const loadHandler = () => {
+  jest.resetModules();
+  process.env.SUPABASE_URL = 'url';
+  process.env.SUPABASE_SERVICE_KEY = 'key';
+  const code = fs.readFileSync(path.join(__dirname, '../netlify/functions/vote.js'), 'utf8');
+  const module = { exports: {} };
+  const customRequire = (p) => {
+    if (p === '@supabase/supabase-js') {
+      return { createClient: globalThis.createClientMock };
+    }
+    return require(p);
+  };
+  const wrapper = new Function('exports','require','module','__filename','__dirname',code);
+  wrapper(module.exports, customRequire, module, path.join(__dirname,'../netlify/functions/vote.js'), path.join(__dirname,'../netlify/functions'));
+  return module.exports.handler;
+};
+
+describe('vote ip detection', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-10T12:00:00Z'));
+    globalThis.createClientMock = jest.fn(() => supabaseMock);
+    supabaseMock = {
+      from: jest.fn(() => supabaseMock),
+      select: jest.fn(() => supabaseMock),
+      eq: jest.fn(() => supabaseMock),
+      gte: jest.fn(() => Promise.resolve({ data: [], error: null })),
+      insert: jest.fn(() => Promise.resolve({ error: null })),
+      update: jest.fn(() => Promise.resolve({ error: null })),
+      delete: jest.fn(() => Promise.resolve({ error: null })),
+      single: jest.fn(() => Promise.resolve({ data: null, error: { code: 'PGRST116' } }))
+    };
+    globalThis.createClientMock.mockReturnValue(supabaseMock);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('uses client-ip header when present', async () => {
+    const handler = loadHandler();
+    await handler({
+      httpMethod: 'POST',
+      headers: { 'client-ip': '1.1.1.1' },
+      body: JSON.stringify({ place: 'a' })
+    });
+    expect(supabaseMock.eq).toHaveBeenCalledWith('ip', '1.1.1.1');
+  });
+
+  test('falls back to x-nf-client-connection-ip', async () => {
+    const handler = loadHandler();
+    await handler({
+      httpMethod: 'POST',
+      headers: { 'x-nf-client-connection-ip': '2.2.2.2' },
+      body: JSON.stringify({ place: 'a' })
+    });
+    expect(supabaseMock.eq).toHaveBeenCalledWith('ip', '2.2.2.2');
+  });
+
+  test('falls back to x-forwarded-for', async () => {
+    const handler = loadHandler();
+    await handler({
+      httpMethod: 'POST',
+      headers: { 'x-forwarded-for': '3.3.3.3, 4.4.4.4' },
+      body: JSON.stringify({ place: 'a' })
+    });
+    expect(supabaseMock.eq).toHaveBeenCalledWith('ip', '3.3.3.3');
+  });
+});


### PR DESCRIPTION
## Summary
- support more IP headers in the Netlify vote function
- test IP detection logic with fallbacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684999d5ea0c8323b8ccc0f4b867378c