### PR TITLE
Centralize Supabase configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Para ejecutar las funciones de Netlify se necesitan dos variables de entorno:
 
 Estas variables deben estar disponibles en el entorno donde se despliegan las funciones serverless `netlify/functions/vote.js` y `netlify/functions/updateAttendance.js`.
 
+En el frontend, las credenciales de Supabase se definen en `config.js`. Los archivos `index.html`, `admin.html` y `votacion.html` importan estas constantes desde ese módulo en lugar de declararlas de forma individual.
+
 
 ## Proceso Semanal
 

--- a/admin.html
+++ b/admin.html
@@ -7,7 +7,6 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="config.js"></script>
   <style>
     body {
       background: linear-gradient(135deg, #1a1a2e, #16213e);
@@ -216,11 +215,11 @@
     </div>
   </div>
 
-  <script>
+  <script type="module">
     // ========== CONFIGURACIÓN SUPABASE ==========
-    const supabaseUrl = 'https://wjwsdyrkqvxszlclitru.supabase.co';
-    const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indqd3NkeXJrcXZ4c3psY2xpdHJ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc0MTA1NzgsImV4cCI6MjA2Mjk4NjU3OH0.YmNDUjkQJrlk91O-Avv7G2QJzQ0R6u9xkR-eIwoAJLo';
+    import { supabaseUrl, supabaseKey, ADMIN_EMAILS } from './config.js';
     const supabase = window.supabase.createClient(supabaseUrl, supabaseKey);
+    window.supabase = supabase;
 
     // ========== CONFIGURACIÓN DE ADMINS ==========
 
@@ -742,6 +741,15 @@
 
     // Inicializar
   init();
+    // Expose functions for onclick handlers
+    window.createNewWeek = createNewWeek;
+    window.finalizeCurrentWeek = finalizeCurrentWeek;
+    window.resetCurrentVotes = resetCurrentVotes;
+    window.resetAttendances = resetAttendances;
+    window.runWeeklyProcess = runWeeklyProcess;
+    window.migrateOldData = migrateOldData;
+    window.deleteUser = deleteUser;
+    window.deleteWeek = deleteWeek;
   </script>
   <script src="weekEdit.js"></script>
 </body>

--- a/config.js
+++ b/config.js
@@ -1,5 +1,15 @@
-// Global configuration
-const ADMIN_EMAILS = [
+// Global configuration shared between the client pages
+export const supabaseUrl = 'https://wjwsdyrkqvxszlclitru.supabase.co';
+export const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indqd3NkeXJrcXZ4c3psY2xpdHJ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc0MTA1NzgsImV4cCI6MjA2Mjk4NjU3OH0.YmNDUjkQJrlk91O-Avv7G2QJzQ0R6u9xkR-eIwoAJLo';
+
+export const ADMIN_EMAILS = [
   'ahidalgod@gmail.com',
   'admin2@example.com'
 ];
+
+// Also expose them on window for non-module scripts if running in browser
+if (typeof window !== 'undefined') {
+  window.supabaseUrl = supabaseUrl;
+  window.supabaseKey = supabaseKey;
+  window.ADMIN_EMAILS = ADMIN_EMAILS;
+}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="config.js"></script>
   <style>
     /* ========== GLOBAL STYLES ========== */
     * {
@@ -1082,11 +1081,11 @@
     </div>
   </div>
 
-  <script>
+  <script type="module">
     // ========== CONFIGURATION ==========
-    const supabaseUrl = 'https://wjwsdyrkqvxszlclitru.supabase.co';
-    const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indqd3NkeXJrcXZ4c3psY2xpdHJ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc0MTA1NzgsImV4cCI6MjA2Mjk4NjU3OH0.YmNDUjkQJrlk91O-Avv7G2QJzQ0R6u9xkR-eIwoAJLo';
+    import { supabaseUrl, supabaseKey, ADMIN_EMAILS } from './config.js';
     const supabase = window.supabase.createClient(supabaseUrl, supabaseKey);
+    window.supabase = supabase;
 
     let bars = []; // Will be loaded from Supabase
 

--- a/votacion.html
+++ b/votacion.html
@@ -204,7 +204,7 @@
     </div>
   </div>
 
-  <script>
+  <script type="module">
     // --------- DATOS ---------
     const bars = [
       { name: "Hooligans Alas", ig: "https://www.instagram.com/hooligans_cr/" },
@@ -232,9 +232,9 @@
     ];
 
     // --------- SUPABASE CONNECTION ---------
-    const supabaseUrl = 'https://wjwsdyrkqvxszlclitru.supabase.co';
-    const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indqd3NkeXJrcXZ4c3psY2xpdHJ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc0MTA1NzgsImV4cCI6MjA2Mjk4NjU3OH0.YmNDUjkQJrlk91O-Avv7G2QJzQ0R6u9xkR-eIwoAJLo';
+    import { supabaseUrl, supabaseKey } from './config.js';
     const supabase = window.supabase.createClient(supabaseUrl, supabaseKey);
+    window.supabase = supabase;
 
     async function getIP() {
       try {


### PR DESCRIPTION
## Summary
- move Supabase keys into `config.js`
- load Supabase constants in the HTML files
- document the config module in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684999a1d2ec83239457e2f274baba11