### PR TITLE
Add JSON header to updateAttendance fetch

### DIFF
--- a/tests/weekEdit.test.js
+++ b/tests/weekEdit.test.js
@@ -49,6 +49,7 @@ describe('saveWeekChanges', () => {
       '/.netlify/functions/updateAttendance',
       expect.objectContaining({
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           weekId: 1,
           bar: 'Bar1',

--- a/weekEdit.js
+++ b/weekEdit.js
@@ -57,6 +57,7 @@ async function saveWeekChanges() {
   try {
     const res = await fetch('/.netlify/functions/updateAttendance', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         weekId: editingWeekId,
         bar,


### PR DESCRIPTION
## Summary
- send `Content-Type: application/json` header when saving week
- expect the header in the week edit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68499ce6ea7c8323b62628b31a68cecc