### PR TITLE
Display status in weekEdit error path

### DIFF
--- a/tests/weekEdit.test.js
+++ b/tests/weekEdit.test.js
@@ -60,4 +60,20 @@ describe('saveWeekChanges', () => {
     expect(hideMock).toHaveBeenCalled();
     expect(_getEditingWeekId()).toBeNull();
   });
+
+  test('shows status code and error message when request fails', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: 'Bad request' }),
+    });
+
+    await saveWeekChanges();
+
+    expect(global.showAlert).toHaveBeenCalledWith(
+      'Error actualizando semana: 400: Bad request',
+      'danger'
+    );
+    expect(_getEditingWeekId()).toBeNull();
+  });
 });

--- a/weekEdit.js
+++ b/weekEdit.js
@@ -65,7 +65,9 @@ async function saveWeekChanges() {
     });
 
     const data = await res.json();
-    if (!res.ok) throw new Error(data.error || 'Request failed');
+    if (!res.ok) {
+      throw new Error(`${res.status}: ${data.error || 'Request failed'}`);
+    }
 
     const modal = bootstrap.Modal.getInstance(document.getElementById('editWeekModal'));
     modal.hide();


### PR DESCRIPTION
## Summary
- include HTTP status in update failure error messages
- test error handling for `saveWeekChanges`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68499ce880608323962c1c69a1bd0d32