### PR TITLE
Implement update_week_and_visits RPC

### DIFF
--- a/sql/update_week_and_visits.sql
+++ b/sql/update_week_and_visits.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION update_week_and_visits(
+    week_id bigint,
+    bar text,
+    attendees text[]
+) RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Update the week summary
+    UPDATE semanas_cn
+       SET bar_ganador = bar,
+           total_asistentes = COALESCE(array_length(attendees, 1), 0),
+           hubo_quorum = COALESCE(array_length(attendees, 1), 0) >= 3
+     WHERE id = week_id;
+
+    -- Replace attendance rows
+    DELETE FROM asistencias WHERE semana_id = week_id;
+
+    IF attendees IS NOT NULL AND array_length(attendees, 1) > 0 THEN
+        INSERT INTO asistencias (user_id, semana_id, confirmado)
+        SELECT a, week_id, TRUE FROM unnest(attendees) AS a;
+    END IF;
+
+    -- Record the latest visit for the bar
+    IF bar IS NOT NULL THEN
+        INSERT INTO visitas_bares (bar, semana_id)
+        VALUES (bar, week_id)
+        ON CONFLICT (bar) DO UPDATE
+          SET semana_id = EXCLUDED.semana_id;
+    END IF;
+END;
+$$;

--- a/tests/updateAttendance.test.js
+++ b/tests/updateAttendance.test.js
@@ -41,11 +41,7 @@ const loadHandler = () => {
 describe('updateAttendance handler', () => {
   beforeEach(() => {
     supabaseMock = {
-      from: jest.fn(() => supabaseMock),
-      update: jest.fn(() => supabaseMock),
-      delete: jest.fn(() => supabaseMock),
-      insert: jest.fn(() => Promise.resolve({ error: null })),
-      eq: jest.fn(() => Promise.resolve({ error: null }))
+      rpc: jest.fn(() => Promise.resolve({ error: null }))
     };
     globalThis.createClientMock = jest.fn(() => supabaseMock);
   });
@@ -59,13 +55,11 @@ describe('updateAttendance handler', () => {
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ success: true });
-    expect(supabaseMock.from).toHaveBeenCalledWith('semanas_cn');
-    expect(supabaseMock.from).toHaveBeenCalledWith('asistencias');
-    expect(supabaseMock.update).toHaveBeenCalled();
-    expect(supabaseMock.delete).toHaveBeenCalled();
-    expect(supabaseMock.insert).toHaveBeenCalled();
-    expect(supabaseMock.eq).toHaveBeenCalledWith('id', 1);
-    expect(supabaseMock.eq).toHaveBeenCalledWith('semana_id', 1);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('update_week_and_visits', {
+      week_id: 1,
+      bar: 'Bar',
+      attendees: ['u1', 'u2']
+    });
   });
 
   test('returns 400 when weekId missing', async () => {


### PR DESCRIPTION
## Summary
- add `update_week_and_visits` SQL function
- refactor `updateAttendance` Netlify function to use the new RPC
- update tests to mock and verify RPC call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a6d72a5c8323909d38f314dd46a3