### PR TITLE
Add local development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Estas variables deben estar disponibles en el entorno donde se despliegan las fu
 
 En el frontend, las credenciales de Supabase se definen en `config.js`. Los archivos `index.html`, `admin.html` y `votacion.html` importan estas constantes desde ese módulo en lugar de declararlas de forma individual.
 
+## Local Development
+
+Para que las rutas `/.netlify/functions/*` funcionen correctamente se deben servir los archivos HTML con Netlify.
+
+```bash
+npm install -g netlify-cli        # if not installed
+netlify dev                        # runs functions locally
+```
+
+Antes de ejecutar `netlify dev` asegúrate de que las variables `SUPABASE_URL` y `SUPABASE_SERVICE_KEY` estén disponibles en el entorno. Si abres los archivos HTML directamente sin usar Netlify el `fetch` en `weekEdit.js` fallará.
+
 
 ## Proceso Semanal
 


### PR DESCRIPTION
## Summary
- document how to serve locally via Netlify
- show commands to run Netlify dev with env vars
- clarify `weekEdit.js` fetch fails if HTML opened directly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bd6b41848323b8245a733cf39a1f