### PR TITLE
Add average participation stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -903,6 +903,10 @@
               <div style="font-weight: 500; margin-bottom: 4px;">🎉 Próximo aniversario:</div>
               <div id="mobileAnniversary" style="font-size: 0.9rem; color: #adb5bd;">Cargando...</div>
             </div>
+            <div style="background: rgba(255,255,255,0.05); border-radius: 6px; padding: 12px;">
+              <div style="font-weight: 500; margin-bottom: 4px;">📊 Promedio de participación:</div>
+              <div id="mobileAverageAttendance" style="font-size: 0.9rem; color: #adb5bd;">Cargando...</div>
+            </div>
           </div>
         </div>
       </section>
@@ -1034,6 +1038,10 @@
                 <strong>🎉 Próximo aniversario:</strong><br>
                 <span id="desktopAnniversary" class="text-warning">Cargando...</span>
               </div>
+                <div class="mb-3">
+                  <strong>📊 Promedio de participación:</strong><br>
+                  <span id="desktopAverageAttendance" class="text-info">Cargando...</span>
+                </div>
             </div>
           </div>
         </div>
@@ -2129,7 +2137,7 @@
           { data: weeksData, error: weeksError },
           { data: userRankingData, error: userRankingError }
         ] = await Promise.all([
-          supabase.from('semanas_cn').select('bar_ganador').eq('estado', 'finalizada').not('bar_ganador', 'is', null),
+          supabase.from('semanas_cn').select('bar_ganador, total_asistentes').eq('estado', 'finalizada').not('bar_ganador', 'is', null),
           supabase.from('asistencias')
             .select('user_id, semana_id, usuarios!inner(nombre), semanas_cn!inner(fecha_martes, estado)')
             .eq('confirmado', true)
@@ -2137,6 +2145,12 @@
         ]);
 
         const totalCNs = weeksData?.length || 0;
+        const totalAttendees = (weeksData || []).reduce((sum, w) => sum + (w.total_asistentes || 0), 0);
+        const avgAttendance = totalCNs ? (totalAttendees / totalCNs).toFixed(1) : 0;
+        const avgMobileEl = document.getElementById('mobileAverageAttendance');
+        if (avgMobileEl) {
+          avgMobileEl.textContent = `${avgAttendance} personas`;
+        }
         
         // Process top bars from historical data
         const topBarsEl = document.getElementById('mobileTopBars');
@@ -2386,7 +2400,7 @@
         ] = await Promise.all([
           supabase
             .from('semanas_cn')
-            .select('id, bar_ganador, fecha_martes')
+            .select('id, bar_ganador, fecha_martes, total_asistentes')
             .eq('estado', 'finalizada')
             .not('bar_ganador', 'is', null)
             .order('fecha_martes', { ascending: false }),
@@ -2398,6 +2412,12 @@
         ]);
 
         const totalCNs = weeksData?.length || 0;
+        const totalAttendees = (weeksData || []).reduce((sum, w) => sum + (w.total_asistentes || 0), 0);
+        const avgAttendance = totalCNs ? (totalAttendees / totalCNs).toFixed(1) : 0;
+        const avgDesktopEl = document.getElementById('desktopAverageAttendance');
+        if (avgDesktopEl) {
+          avgDesktopEl.textContent = `${avgAttendance} personas`;
+        }
 
         // ===== Top Bars =====
         const topBarsEl = document.getElementById('desktopTopBars');


### PR DESCRIPTION
## Summary
- display Promedio de participación on mobile/desktop history cards
- calculate average attendance per CN in stats loaders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871a0294f608323818838937a4de7f5