### PR TITLE
Update subtitle with days left until next CN

### DIFF
--- a/index.html
+++ b/index.html
@@ -1397,6 +1397,20 @@
       return `${day}-${month}`;
     }
 
+    function formatTuesdayDateLongNoYear(date) {
+      const day = date.getDate().toString().padStart(2, '0');
+      const month = date.toLocaleDateString('es-ES', { month: 'long' });
+      return `${day}-${month}`;
+    }
+
+    function daysUntil(date) {
+      const today = new Date();
+      const start = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+      const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+      const diff = target.getTime() - start.getTime();
+      return Math.ceil(diff / (1000 * 60 * 60 * 24));
+    }
+
     function calculateTotalCNs() {
       // Start from first Tuesday of August 2003
       const startDate = new Date(2003, 7, 5); // August 5, 2003 was a Tuesday
@@ -1622,16 +1636,17 @@
         currentWeek = data;
         
         const nextTuesday = getNextTuesday();
-        const formattedDate = formatTuesdayDate(nextTuesday);
+        const formattedDate = formatTuesdayDateLongNoYear(nextTuesday);
         const totalCNs = calculateTotalCNs();
-        const weekText = `Próximo martes ${formattedDate} • CN #${totalCNs}`;
+        const remainingDays = daysUntil(nextTuesday);
+        const weekText = `Martes ${formattedDate} - CN #${totalCNs} - Faltan ${remainingDays}`;
         
         if (isMobile) {
           const el = document.getElementById('mobileWeekInfo');
           if (el) el.textContent = weekText;
         } else {
           const el = document.getElementById('desktopWeekInfo');
-          if (el) el.innerHTML = `Semana del martes ${formatTuesdayDate(parseLocalDate(currentWeek.fecha_martes))} - <span class="cn-number">CN #${totalCNs}</span>`;
+          if (el) el.innerHTML = `Martes ${formattedDate} - <span class="cn-number">CN #${totalCNs}</span> - Faltan ${remainingDays}`;
         }
       } catch (error) {
         console.error('❌ Error en loadCurrentWeek:', error);


### PR DESCRIPTION
## Summary
- show days left until the next Tuesday
- display long month name for next CN date on both layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68750ced45148323baac3f5f5e682b2c