### PR TITLE
Redesign mobile bar cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,26 +231,29 @@
     .mobile-bars-container {
       background: rgba(255, 255, 255, 0.02);
       border-radius: 16px;
-      overflow: hidden;
-      border: 1px solid rgba(255, 255, 255, 0.05);
+      padding: 4px;
     }
 
     .mobile-bar-item {
-      background: rgba(40, 40, 40, 0.8);
+      background: #3e2f1c;
       padding: 18px 20px;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-      transition: background 0.2s ease;
+      border-radius: 12px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+      margin-bottom: 12px;
+      transition: background 0.2s ease, transform 0.2s ease;
     }
 
-    .mobile-bar-item:last-child {
-      border-bottom: none;
+    .mobile-bar-item.voted-card {
+      background: #5e3b1e;
+      animation: scaleIn 0.25s ease-out;
     }
 
-    .mobile-bar-item:hover {
-      background: rgba(50, 50, 50, 0.8);
+    @keyframes scaleIn {
+      from { transform: scale(0.95); opacity: 0; }
+      to { transform: scale(1); opacity: 1; }
     }
 
     .mobile-bar-left {
@@ -311,24 +314,36 @@
       flex-shrink: 0;
     }
 
+    .beer-icon {
+      font-size: 1.5rem;
+      margin-left: 8px;
+    }
+
+    .beer-icon.animate {
+      animation: beerBounce 1s infinite;
+    }
+
+    @keyframes beerBounce {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+
     .mobile-vote-btn {
-      background: #4a5568;
-      color: white;
+      background: #fff3c2;
+      color: #3e2f1c;
       border: none;
       border-radius: 10px;
       padding: 10px 18px;
       font-size: 0.9rem;
-      font-weight: 600;
+      font-weight: 700;
       min-width: 75px;
-      transition: all 0.2s ease;
+      transition: background 0.2s ease, transform 0.2s ease;
       cursor: pointer;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
     }
 
-    .mobile-vote-btn.voted {
-      background: #008d4e;
-      transform: scale(1.02);
+    .mobile-vote-btn.pulse {
+      animation: pulse 0.4s ease;
+      background: #ffe066;
     }
 
     .mobile-vote-btn:disabled {
@@ -337,8 +352,10 @@
       cursor: not-allowed;
     }
 
-    .mobile-vote-btn:hover:not(:disabled) {
-      filter: brightness(1.1);
+    @keyframes pulse {
+      0% { transform: scale(1); }
+      50% { transform: scale(1.1); }
+      100% { transform: scale(1); }
     }
 
     /* Mobile Attendance */
@@ -1794,9 +1811,9 @@
         }
         
         return `
-          <div class="mobile-bar-item ${isWinner ? 'winner-highlight' : ''}">
+          <div class="mobile-bar-item ${isWinner ? 'winner-highlight' : ''} ${userVoted ? 'voted-card' : ''}">
             <div class="mobile-bar-left">
-              <div class="mobile-bar-votes ${votes > 0 ? 'has-votes' : ''}" 
+              <div class="mobile-bar-votes ${votes > 0 ? 'has-votes' : ''}"
                    ${votes > 0 ? `onclick="showVoteDetails('${bar.name}', ${votes})"` : ''}>
                 ${votes}
               </div>
@@ -1808,11 +1825,9 @@
               </div>
             </div>
             <div class="mobile-bar-right">
-              <button class="mobile-vote-btn ${userVoted ? 'voted' : ''}"
-                      ${!isActive ? 'disabled' : ''}
-                      onclick="toggleVote('${bar.name}', this)">
-                ${userVoted ? '🍺' : 'Vote'}
-              </button>
+              ${userVoted
+                ? '<span class="beer-icon animate">🍺</span>'
+                : `<button class="mobile-vote-btn" ${!isActive ? 'disabled' : ''} onclick="toggleVote('${bar.name}', this)">VOTAR</button>`}
             </div>
           </div>
         `;
@@ -2031,6 +2046,10 @@
       }
 
       const originalText = btnElement.textContent;
+      if (!userVotes.includes(barName)) {
+        btnElement.classList.add('pulse');
+        setTimeout(() => btnElement.classList.remove('pulse'), 400);
+      }
       btnElement.textContent = '⏳';
       btnElement.disabled = true;
 


### PR DESCRIPTION
## Summary
- tweak mobile bar item design
- highlight voted cards with lighter background
- animate beer icon when user has voted
- show pulse animation on vote

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68752b7e65a08323ba1fb3ab0d9be7c8