### PR TITLE
Add animations and info modal for votes

### DIFF
--- a/votacion.html
+++ b/votacion.html
@@ -100,6 +100,47 @@
       background: #e74c3c;
       color: #fff;
     }
+    .vote-row-animate {
+      animation: voteFlash 0.6s ease;
+    }
+    @keyframes voteFlash {
+      0% { transform: scale(1); background-color: transparent; }
+      50% { transform: scale(1.05); background-color: rgba(255, 224, 102, 0.2); }
+      100% { transform: scale(1); background-color: transparent; }
+    }
+    .confetti {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      overflow: hidden;
+      z-index: 1050;
+    }
+    .confetti span {
+      position: absolute;
+      animation: fall 1s ease-out forwards;
+      font-size: 24px;
+    }
+    @keyframes fall {
+      0% { transform: translateY(0) rotate(0); opacity: 1; }
+      100% { transform: translateY(100vh) rotate(360deg); opacity: 0; }
+    }
+    #finalRanking {
+      display: none;
+      background: rgba(0,0,0,0.6);
+      border-radius: 1em;
+      padding: 1em 1.5em;
+      margin-top: 1.5em;
+      color: #ffe066;
+      text-align: center;
+      opacity: 0;
+      transition: opacity 0.8s ease;
+    }
+    #finalRanking.reveal {
+      opacity: 1;
+    }
     .votes-cell {
       font-size: 1.2em;
       font-weight: 700;
@@ -156,6 +197,7 @@
   <a href="index.html" class="back-btn">⬅️ Volver</a>
   <div class="main-content">
     <div id="winner" class="winner-box" style="display:none"></div>
+    <div id="finalRanking"></div>
     <h2 class="mb-4 mt-2" style="color:#ffe066; text-shadow: 2px 3px 8px #0008; font-size:2rem; font-weight:700;">¿A dónde vamos este martes?</h2>
     <!-- Tabla de votos -->
     <div class="table-responsive" style="width:100%;max-width:900px;">
@@ -200,6 +242,19 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-light" id="submitPinBtn">Borrar todo</button>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- MODAL INFO EXTRA -->
+  <div class="modal fade" id="infoModal" tabindex="-1" aria-labelledby="infoModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content bg-dark text-light">
+        <div class="modal-header">
+          <h5 class="modal-title" id="infoModalLabel">Info</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body" id="infoModalBody"></div>
       </div>
     </div>
   </div>
@@ -263,6 +318,14 @@
       userVotes = {};
       data.filter(d => d.ip === ip).forEach(d => { userVotes[d.bar] = true; });
       renderTable();
+      if (isVotingClosed()) {
+        const sorted = votes.slice().sort((a, b) => {
+          if (b.votes !== a.votes) return b.votes - a.votes;
+          if (b.votes === 0 && a.votes === 0) return a.name.localeCompare(b.name);
+          return 0;
+        });
+        showFinalRanking(sorted);
+      }
     }
 
     function igIcon() {
@@ -289,7 +352,7 @@
         if (!igCell) igCell = '<span style="color:#bbb;">—</span>';
         const voted = userVotes[bar.name];
         tbody.innerHTML += `
-          <tr>
+          <tr onmousedown="longPressStart('${bar.name}', this)" onmouseup="longPressEnd()" ontouchstart="longPressStart('${bar.name}', this)" ontouchend="longPressEnd()">
             <td>${bar.name}</td>
             <td>${igCell}</td>
             <td>
@@ -314,6 +377,12 @@
         alert('Error al votar, intenta de nuevo');
         return;
       }
+      launchBeerConfetti();
+      const row = btn.closest('tr');
+      if (row) {
+        row.classList.add('vote-row-animate');
+        setTimeout(() => row.classList.remove('vote-row-animate'), 600);
+      }
       await fetchVotes();
     }
 
@@ -332,6 +401,61 @@
         winnerDiv.innerHTML = `🍻 Empate entre: ${names} 🍻`;
       }
       winnerDiv.style.display = "block";
+    }
+
+    function launchBeerConfetti() {
+      const container = document.createElement('div');
+      container.className = 'confetti';
+      document.body.appendChild(container);
+      for (let i = 0; i < 20; i++) {
+        const span = document.createElement('span');
+        span.textContent = '🍺';
+        span.style.left = Math.random() * 100 + '%';
+        span.style.animationDelay = (Math.random() * 0.5) + 's';
+        container.appendChild(span);
+      }
+      setTimeout(() => container.remove(), 1500);
+    }
+
+    let longPressTimeout;
+    function longPressStart(bar, row) {
+      longPressTimeout = setTimeout(() => showBarInfo(bar), 600);
+    }
+    function longPressEnd() {
+      clearTimeout(longPressTimeout);
+    }
+
+    function showBarInfo(barName) {
+      const info = votes.find(v => v.name === barName) || { votes: 0, ips: [] };
+      const bar = bars.find(b => b.name === barName) || {};
+      let html = `<p><strong>Votos:</strong> ${info.votes}</p>`;
+      if (info.ips.length) {
+        html += `<p><strong>IPs:</strong> ${info.ips.join(', ')}</p>`;
+      }
+      if (bar.map) {
+        html += `<p><a href="${bar.map}" target="_blank">Ver mapa</a></p>`;
+      }
+      if (!html) html = '<p>Sin información adicional</p>';
+      document.getElementById('infoModalLabel').textContent = barName;
+      document.getElementById('infoModalBody').innerHTML = html;
+      new bootstrap.Modal(document.getElementById('infoModal')).show();
+    }
+
+    function isVotingClosed() {
+      const now = new Date();
+      const start = new Date(now);
+      start.setDate(now.getDate() - ((now.getDay() + 5) % 7));
+      start.setHours(19,0,0,0);
+      return now >= start;
+    }
+
+    function showFinalRanking(sorted) {
+      const ranking = document.getElementById('finalRanking');
+      ranking.innerHTML = '<h4>\uD83C\uDFC6 Ranking final</h4><ol>' +
+        sorted.map(b => `<li>${b.name} - ${b.votes}</li>`).join('') +
+        '</ol>';
+      ranking.style.display = 'block';
+      setTimeout(() => ranking.classList.add('reveal'), 50);
     }
 
     fetchVotes();

--- a/votacion.html
+++ b/votacion.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-bs-theme="dark">
 <head>
   <meta charset="UTF-8">
   <title>¿A dónde vamos este martes?</title>
@@ -18,6 +18,39 @@
     body {
       background: url('fondo.png') no-repeat center center fixed;
       background-size: cover;
+    }
+    .loader {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: #000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+    }
+    .beer {
+      width: 60px;
+      height: 80px;
+      border: 4px solid #fff;
+      border-radius: 0 0 10px 10px;
+      position: relative;
+      overflow: hidden;
+    }
+    .beer-liquid {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 0;
+      background: #ffbf00;
+      animation: fillBeer 2s forwards;
+    }
+    @keyframes fillBeer {
+      from { height: 0; }
+      to { height: 100%; }
     }
     .overlay {
       position: fixed;
@@ -163,6 +196,20 @@
     .ig-icon {
       filter: drop-shadow(0 0 4px #ffe06688);
     }
+    [data-bs-theme="light"] body {
+      color: #000;
+    }
+    [data-bs-theme="light"] .overlay {
+      background: rgba(255,255,255,0.5);
+    }
+    [data-bs-theme="light"] table {
+      background: rgba(255,255,255,0.9);
+      color: #000;
+    }
+    [data-bs-theme="light"] th {
+      background: #eee;
+      color: #333;
+    }
     @media (max-width: 700px) {
       .main-content { padding: 2vw; }
       table { font-size: 0.93em; }
@@ -193,15 +240,27 @@
   </style>
 </head>
 <body>
+  <div id="loader" class="loader" style="display:flex">
+    <div class="beer">
+      <div class="beer-liquid"></div>
+    </div>
+  </div>
   <div class="overlay"></div>
   <a href="index.html" class="back-btn">⬅️ Volver</a>
   <div class="main-content">
+    <div class="d-flex align-items-center gap-2" style="margin-top:1rem;">
+      <div id="countdown" style="font-size:1.1rem;color:#ffe066;"></div>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="themeToggle">
+        <label class="form-check-label" for="themeToggle">🌙/☀️</label>
+      </div>
+    </div>
     <div id="winner" class="winner-box" style="display:none"></div>
     <div id="finalRanking"></div>
     <h2 class="mb-4 mt-2" style="color:#ffe066; text-shadow: 2px 3px 8px #0008; font-size:2rem; font-weight:700;">¿A dónde vamos este martes?</h2>
     <!-- Tabla de votos -->
     <div class="table-responsive" style="width:100%;max-width:900px;">
-      <table class="table table-dark table-hover align-middle mt-2">
+      <table id="voteTable" class="table table-dark table-hover align-middle mt-2">
         <thead>
           <tr>
             <th>Lugar</th>
@@ -458,7 +517,49 @@
       setTimeout(() => ranking.classList.add('reveal'), 50);
     }
 
+    function startCountdown() {
+      const el = document.getElementById('countdown');
+      if (!el) return;
+      function update() {
+        const now = new Date();
+        const closing = new Date();
+        closing.setHours(19, 0, 0, 0);
+        if (now >= closing) {
+          el.textContent = 'Votación cerrada';
+          document.querySelectorAll('.vote-btn').forEach(b => b.disabled = true);
+          return;
+        }
+        const diff = closing - now;
+        const h = Math.floor(diff / 3600000);
+        const m = Math.floor((diff % 3600000) / 60000);
+        const s = Math.floor((diff % 60000) / 1000);
+        el.textContent = `Cierre en ${h}h ${m}m ${s}s`;
+      }
+      update();
+      setInterval(update, 1000);
+    }
+
+    function initTheme() {
+      const toggle = document.getElementById('themeToggle');
+      if (!toggle) return;
+      const saved = localStorage.getItem('theme') || 'dark';
+      document.documentElement.setAttribute('data-bs-theme', saved);
+      toggle.checked = saved === 'light';
+      toggle.addEventListener('change', () => {
+        const theme = toggle.checked ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        localStorage.setItem('theme', theme);
+      });
+    }
+
+    window.addEventListener('load', () => {
+      const loader = document.getElementById('loader');
+      if (loader) loader.style.display = 'none';
+    });
+
     fetchVotes();
+    startCountdown();
+    initTheme();
     window.vote = vote;
 
     // ========== LOGICA BOTON CERVEZA ADMIN ==========


### PR DESCRIPTION
## Summary
- add beer confetti, card animation and final ranking container
- allow long press on rows to show extra bar info
- trigger confetti and animation after vote action
- reveal final ranking once voting is closed

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68752bbb57948323859346719dc5cef1