### PR TITLE
Update mobile nav styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
       from { text-shadow: 0 0 5px #ffd700; }
       to { text-shadow: 0 0 10px #ffd700, 0 0 15px #ffd700; }
     }
+    @keyframes fadeSlide {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
 
     /* ========== MOBILE DESIGN ========== */
     .mobile-layout {
@@ -55,7 +59,6 @@
     /* Mobile Header */
     .mobile-header {
       background: rgba(26, 26, 26, 0.95);
-      backdrop-filter: blur(10px);
       padding: 16px;
       position: fixed;
       top: 0;
@@ -128,7 +131,6 @@
       top: 45px;
       right: 0;
       background: rgba(40, 40, 40, 0.95);
-      backdrop-filter: blur(10px);
       border-radius: 12px;
       border: 1px solid rgba(255, 224, 102, 0.3);
       min-width: 140px;
@@ -159,6 +161,8 @@
     /* Mobile Main Content */
     .mobile-main {
       flex: 1;
+    .mobile-main {
+      flex: 1;
       padding: 100px 0 100px 0;
       overflow-y: auto;
     }
@@ -170,6 +174,7 @@
 
     .mobile-section.active {
       display: block;
+      animation: fadeSlide 0.3s ease;
     }
 
     /* Mobile Bottom Navigation */
@@ -178,8 +183,7 @@
       bottom: 0;
       left: 0;
       right: 0;
-      background: rgba(26, 26, 26, 0.95);
-      backdrop-filter: blur(10px);
+      background: #1e1b16;
       border-top: 1px solid rgba(255, 224, 102, 0.2);
       padding: 12px 0 calc(12px + env(safe-area-inset-bottom));
       z-index: 1000;
@@ -206,8 +210,9 @@
     }
 
     .mobile-nav-item.active {
-      color: #ffe066;
-      background: rgba(255, 224, 102, 0.1);
+      color: #facc15;
+      font-weight: 700;
+      background: rgba(250, 204, 21, 0.1);
     }
 
     .mobile-nav-item:not(.active) {
@@ -215,8 +220,8 @@
     }
 
     .mobile-nav-icon {
-      width: 22px;
-      height: 22px;
+      width: 30px;
+      height: 30px;
       margin-bottom: 4px;
       fill: currentColor;
       stroke: currentColor;
@@ -915,29 +920,23 @@
     <nav class="mobile-bottom-nav">
       <div class="mobile-nav-items">
         <div class="mobile-nav-item active" data-section="voting">
-          <svg class="mobile-nav-icon" viewBox="0 0 256 256" fill="currentColor">
-            <path d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm-34.34,77.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z"/>
+          <svg class="mobile-nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z"/>
           </svg>
           <div class="mobile-nav-label">Votación</div>
         </div>
         <div class="mobile-nav-item" data-section="attendance">
-          <svg class="mobile-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
-            <circle cx="9" cy="7" r="4"/>
-            <path d="M22 21v-2a4 4 0 0 0-3-3.87"/>
-            <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+          <svg class="mobile-nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"/>
           </svg>
           <div class="mobile-nav-label">Asistencia</div>
         </div>
         <div class="mobile-nav-item" data-section="history">
-          <svg class="mobile-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <line x1="4" y1="9" x2="20" y2="9"/>
-            <line x1="4" y1="15" x2="20" y2="15"/>
-            <line x1="10" y1="3" x2="8" y2="21"/>
-            <line x1="16" y1="3" x2="14" y2="21"/>
+          <svg class="mobile-nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/>
           </svg>
           <div class="mobile-nav-label">Historial</div>
-        </div>
+          </div>
       </div>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- tweak bottom navigation to be fixed on dark background
- use larger Heroicon SVGs
- highlight active tab with gold color and bold text
- add slide/fade animation for section changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68752b843a388323b3bac2a0c17d27ea