### PR TITLE
Add vote progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -847,6 +847,9 @@
         <div>
           <h1 class="app-title">🍺 CORKY NIGHTS</h1>
           <div id="mobileWeekInfo" class="week-info"></div>
+  <div class="vote-progress-container">
+    <div class="vote-progress-bar" id="voteProgressBar"></div>
+  </div>
         </div>
         <div class="mobile-user-info">
           <span id="mobileStreak" class="mobile-streak"></span>
@@ -971,6 +974,9 @@
     <div class="desktop-header">
       <h1>🍺 CORKY NIGHTS 🍺</h1>
       <div id="desktopWeekInfo" class="text-light desktop-week-info"></div>
+      <div class="vote-progress-container">
+        <div class="vote-progress-bar" id="voteProgressBar"></div>
+      </div>
     </div>
 
     <ul class="nav nav-pills justify-content-center desktop-tabs" id="desktopTabs" role="tablist">
@@ -2970,6 +2976,20 @@
     window.saveBarEdit = saveBarEdit;
     window.cancelBarEdit = cancelBarEdit;
     window.signOut = signOut;
+
+    function updateVoteProgressBar(start, end) {
+      const now = new Date();
+      const total = end - start;
+      const elapsed = now - start;
+      const progress = Math.min(100, Math.max(0, (elapsed / total) * 100));
+      const bar = document.getElementById("voteProgressBar");
+      if (bar) bar.style.width = progress + "%";
+    }
+
+    const voteStart = new Date("2025-07-15T00:00:00");
+    const voteEnd = new Date("2025-07-15T20:00:00");
+    updateVoteProgressBar(voteStart, voteEnd);
+    setInterval(() => updateVoteProgressBar(voteStart, voteEnd), 60000);
   </script>
   <div class="modal fade" id="editWeekModal" tabindex="-1">
     <div class="modal-dialog modal-lg">

--- a/styles.css
+++ b/styles.css
@@ -111,3 +111,19 @@ table {
 input[type="text"] {
     background: #edf2f7;
 }
+.vote-progress-container {
+  width: 100%;
+  height: 6px;
+  background-color: #3b2f25;
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 6px;
+}
+
+.vote-progress-bar {
+  height: 100%;
+  background-color: #facc15;
+  width: 0%;
+  transition: width 0.5s ease-in-out;
+}
+


### PR DESCRIPTION
## Summary
- add progress bar in mobile and desktop headers
- style progress bar
- update script to animate bar based on remaining vote time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68754bcb81c8832387d04aff0e684a44