### PR TITLE
Add mobile user stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,6 +387,10 @@
       border: 2px solid rgba(255, 224, 102, 0.3);
     }
 
+    .mobile-user-stats {
+      margin-top: 16px;
+    }
+
     /* Mobile History & Stats */
     .mobile-stats-section {
       margin-bottom: 24px;
@@ -866,6 +870,7 @@
         <div class="mobile-quorum-card">
           <div id="mobileQuorumStatus" class="quorum-status"></div>
           <div id="mobileAttendeesList" class="mobile-attendees"></div>
+          <div id="mobileUserStats" class="mobile-user-stats"></div>
         </div>
       </section>
 
@@ -1747,6 +1752,7 @@
         
         if (isMobile) {
           updateMobileAttendance(attendances || []);
+          loadMobileUserStats();
         } else {
           updateDesktopAttendance(attendances || []);
         }
@@ -2351,6 +2357,88 @@
         
       } catch (error) {
         console.error('❌ Error loading mobile stats:', error);
+      }
+    }
+
+    async function loadMobileUserStats() {
+      const container = document.getElementById('mobileUserStats');
+      if (!container || !currentUser) return;
+
+      container.innerHTML = '<div class="loading"><div class="spinner"></div><span>Cargando...</span></div>';
+
+      try {
+        const { data: attendanceRows, error: attendanceErr } = await supabase
+          .from('asistencias')
+          .select('semana_id')
+          .eq('user_id', currentUser.id)
+          .eq('confirmado', true);
+
+        if (attendanceErr) throw attendanceErr;
+
+        const weekIds = attendanceRows.map(a => a.semana_id);
+        let weeksData = [];
+        if (weekIds.length) {
+          const { data, error } = await supabase
+            .from('semanas_cn')
+            .select('id, fecha_martes')
+            .in('id', weekIds)
+            .eq('estado', 'finalizada')
+            .order('fecha_martes', { ascending: false });
+          if (error) throw error;
+          weeksData = data || [];
+        }
+
+        const { data: votesData, error: votesErr } = await supabase
+          .from('votos')
+          .select('bar, semana_id')
+          .eq('user_id', currentUser.id);
+
+        if (votesErr) throw votesErr;
+
+        const lastAttendanceDate = weeksData[0]?.fecha_martes || null;
+        const attendedCount = weeksData.length;
+        const lastCNText = lastAttendanceDate ? formatTuesdayDateLong(lastAttendanceDate) : 'Nunca';
+
+        const voteCounts = {};
+        (votesData || []).forEach(v => {
+          voteCounts[v.bar] = (voteCounts[v.bar] || 0) + 1;
+        });
+        let mostVoted = null;
+        let maxVotes = 0;
+        Object.entries(voteCounts).forEach(([bar, count]) => {
+          if (count > maxVotes) {
+            mostVoted = bar;
+            maxVotes = count;
+          }
+        });
+
+        const weeksVoted = new Set((votesData || []).map(v => v.semana_id)).size;
+        const avgVotes = weeksVoted ? (votesData.length / weeksVoted).toFixed(1) : '0';
+
+        container.innerHTML = `
+          <div class="mobile-stats-section">
+            <h4 style="color: var(--color-accent); margin-bottom: 12px; font-size: 1rem;">📈 Tus Estadísticas</h4>
+            <div style="background: rgba(255,255,255,0.05); border-radius: 6px; padding: 12px; margin-bottom: 8px;">
+              <div style="font-weight: 500; margin-bottom: 4px;">🕑 Última CN asistida:</div>
+              <div style="font-size: 0.9rem; color: #adb5bd;">${lastCNText}</div>
+            </div>
+            <div style="background: rgba(255,255,255,0.05); border-radius: 6px; padding: 12px; margin-bottom: 8px;">
+              <div style="font-weight: 500; margin-bottom: 4px;">✅ Total asistencias:</div>
+              <div style="font-size: 0.9rem; color: #adb5bd;">${attendedCount}</div>
+            </div>
+            <div style="background: rgba(255,255,255,0.05); border-radius: 6px; padding: 12px; margin-bottom: 8px;">
+              <div style="font-weight: 500; margin-bottom: 4px;">🍺 Bar más votado:</div>
+              <div style="font-size: 0.9rem; color: #adb5bd;">${mostVoted || 'N/A'}</div>
+            </div>
+            <div style="background: rgba(255,255,255,0.05); border-radius: 6px; padding: 12px;">
+              <div style="font-weight: 500; margin-bottom: 4px;">📊 Promedio de votos por CN:</div>
+              <div style="font-size: 0.9rem; color: #adb5bd;">${avgVotes}</div>
+            </div>
+          </div>
+        `;
+      } catch (err) {
+        console.error('❌ Error loading user stats:', err);
+        container.innerHTML = '<div style="color:#ff6e50">Error cargando estadísticas</div>';
       }
     }
 


### PR DESCRIPTION
## Summary
- show personal stats under attendance list on mobile
- load user statistics from Supabase and display
- restructure stats query to avoid join errors

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68757002db688323937da9cd2b59b34a