### PR TITLE
Fix personal stats loading on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2371,7 +2371,7 @@
             .eq('user_id', currentUser.id)
             .eq('confirmado', true)
             .eq('semanas_cn.estado', 'finalizada')
-            .order('semanas_cn.fecha_martes', { ascending: false }),
+            .order('fecha_martes', { foreignTable: 'semanas_cn', ascending: false }),
           supabase
             .from('votos')
             .select('bar, semana_id')


### PR DESCRIPTION
## Summary
- fix Supabase query ordering for mobile user stats

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876ab41697c832394608552d98647e5