### PR TITLE
Refactor updateAttendance handler

### DIFF
--- a/netlify/functions/updateAttendance.js
+++ b/netlify/functions/updateAttendance.js
@@ -1,61 +1,63 @@
 const { createClient } = require('@supabase/supabase-js');
 
-let handler;
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
 
-const missingVars = [];
-if (!process.env.SUPABASE_URL) missingVars.push('SUPABASE_URL');
-if (!process.env.SUPABASE_SERVICE_KEY) missingVars.push('SUPABASE_SERVICE_KEY');
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch (err) {
+    console.error('JSON parse error:', err);
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON' })
+    };
+  }
 
-if (missingVars.length) {
-  const msg = `Missing ${missingVars.join(', ')}`;
-  console.error(msg);
-  handler = async () => ({
-    statusCode: 500,
-    body: JSON.stringify({ error: msg })
-  });
-} else {
+  const missing = [];
+  if (!process.env.SUPABASE_URL) missing.push('SUPABASE_URL');
+  if (!process.env.SUPABASE_KEY) missing.push('SUPABASE_KEY');
+  if (missing.length) {
+    const msg = `Missing environment variables: ${missing.join(', ')}`;
+    console.error(msg);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: msg })
+    };
+  }
+
   const supabase = createClient(
     process.env.SUPABASE_URL,
-    process.env.SUPABASE_SERVICE_KEY
+    process.env.SUPABASE_KEY
   );
 
-  handler = async (event) => {
-    if (event.httpMethod !== 'POST') {
-      return { statusCode: 405, body: 'Method Not Allowed' };
-    }
+  const { id, asistentes } = body;
 
-    try {
-      const { weekId, bar, attendees } = JSON.parse(event.body || '{}');
+  try {
+    const { data, error } = await supabase
+      .from('attendance')
+      .update({ asistentes })
+      .eq('id', id);
 
-      if (!weekId) {
-        return {
-          statusCode: 400,
-          body: JSON.stringify({ error: 'Missing weekId' })
-        };
-      }
-
-      const attendeeIds = (attendees || []).map((id) =>
-        /^\d+$/.test(id) ? parseInt(id, 10) : id
-      );
-
-      const { error: rpcErr } = await supabase.rpc('update_week_and_visits', {
-        week_id: weekId,
-        bar,
-        attendees: attendeeIds
-      });
-      if (rpcErr) throw rpcErr;
-
+    if (error) {
+      console.error('Supabase update error:', error);
       return {
-        statusCode: 200,
-        body: JSON.stringify({ success: true })
-      };
-    } catch (error) {
-      return {
-        statusCode: 500,
+        statusCode: 400,
         body: JSON.stringify({ error: error.message })
       };
     }
-  };
-}
 
-module.exports.handler = handler;
+    return {
+      statusCode: 200,
+      body: JSON.stringify(data)
+    };
+  } catch (err) {
+    console.error('Unexpected error:', err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: err.message })
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- refactor Netlify updateAttendance handler to validate env vars
- parse request body safely and update `attendance` table
- update tests for the new handler behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877b9219c508323af61dea557dea7fa