### PR TITLE
Fix last attendance date selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2379,7 +2379,8 @@
             .from('asistencias')
             .select('semana_id, semanas_cn!inner(fecha_martes, estado)')
             .eq('user_id', currentUser.id)
-            .eq('confirmado', true),
+            .eq('confirmado', true)
+            .eq('semanas_cn.estado', 'finalizada'),
           supabase
             .from('votos')
             .select('bar, semana_id')


### PR DESCRIPTION
## Summary
- only count attendances for finalized weeks when building user stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e107a6ec8323950889e42ab2d510