### PR TITLE
Fix week editing

### DIFF
--- a/netlify/functions/updateAttendance.js
+++ b/netlify/functions/updateAttendance.js
@@ -5,20 +5,21 @@ import { supabase } from '../../src/lib/supabaseClient'
 export const handler = async (event, context) => {
   try {
     // 1. Parsear y validar JSON
-    const { id, asistentes } = JSON.parse(event.body)
-    if (!id || !Array.isArray(asistentes)) {
-      throw new Error('Invalid payload: id and asistentes are required')
+    const { weekId, bar, attendees } = JSON.parse(event.body)
+    if (!weekId) {
+      throw new Error('Invalid payload: weekId is required')
     }
 
-    // 2. Ejecutar la actualización
-    const { data, error } = await supabase
-      .from('attendance')
-      .update({ asistentes })
-      .eq('id', id)
+    // 2. Ejecutar la actualización mediante RPC
+    const { data, error } = await supabase.rpc('update_week_and_visits', {
+      week_id: weekId,
+      bar,
+      attendees,
+    })
 
     // 3. Manejo de errores de Supabase
     if (error) {
-      console.error('Supabase update error:', error)
+      console.error('Supabase RPC error:', error)
       return {
         statusCode: 400,
         headers: { 'Content-Type': 'application/json' },

--- a/tests/updateAttendance.test.js
+++ b/tests/updateAttendance.test.js
@@ -51,9 +51,7 @@ const loadHandler = () => {
 describe('updateAttendance handler', () => {
   beforeEach(() => {
     supabaseMock = {
-      from: jest.fn(() => supabaseMock),
-      update: jest.fn(() => supabaseMock),
-      eq: jest.fn(() => Promise.resolve({ data: { ok: true }, error: null }))
+      rpc: jest.fn(() => Promise.resolve({ data: { ok: true }, error: null }))
     };
     globalThis.createClientMock = jest.fn(() => supabaseMock);
   });
@@ -69,14 +67,16 @@ describe('updateAttendance handler', () => {
     const handler = loadHandler();
     const res = await handler({
       httpMethod: 'POST',
-      body: JSON.stringify({ id: 1, asistentes: ['u1'] })
+      body: JSON.stringify({ weekId: 1, bar: 'Bar1', attendees: ['u1'] })
     });
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ data: { ok: true } });
-    expect(supabaseMock.from).toHaveBeenCalledWith('attendance');
-    expect(supabaseMock.update).toHaveBeenCalledWith({ asistentes: ['u1'] });
-    expect(supabaseMock.eq).toHaveBeenCalledWith('id', 1);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('update_week_and_visits', {
+      week_id: 1,
+      bar: 'Bar1',
+      attendees: ['u1']
+    });
   });
 
   test('returns 502 on invalid JSON with detailed message', async () => {
@@ -98,7 +98,7 @@ describe('updateAttendance handler', () => {
     const handler = loadHandler();
     const res = await handler({
       httpMethod: 'POST',
-      body: JSON.stringify({ id: 1, asistentes: [] })
+      body: JSON.stringify({ weekId: 1, bar: null, attendees: [] })
     });
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary
- update serverless function to use RPC for editing weeks
- adjust tests to match the new implementation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a17d2061c832389c299a43417cbb7