### PR TITLE
Centralize Supabase configuration and simplify vote function

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,11 +1,13 @@
 // Global configuration shared between the client pages
-export const supabaseUrl = 'https://wjwsdyrkqvxszlclitru.supabase.co';
-export const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indqd3NkeXJrcXZ4c3psY2xpdHJ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc0MTA1NzgsImV4cCI6MjA2Mjk4NjU3OH0.YmNDUjkQJrlk91O-Avv7G2QJzQ0R6u9xkR-eIwoAJLo';
+export const supabaseUrl = process.env.SUPABASE_URL || '';
+export const supabaseKey = process.env.SUPABASE_KEY || '';
 
-export const ADMIN_EMAILS = [
-  'ahidalgod@gmail.com',
-  'admin2@example.com'
-];
+export const ADMIN_EMAILS = (process.env.ADMIN_EMAILS
+  ? process.env.ADMIN_EMAILS.split(',')
+  : [
+      'ahidalgod@gmail.com',
+      'admin2@example.com'
+    ]);
 
 // Also expose them on window for non-module scripts if running in browser
 if (typeof window !== 'undefined') {

--- a/netlify/functions/vote.js
+++ b/netlify/functions/vote.js
@@ -1,6 +1,6 @@
-const { createClient } = require('@supabase/supabase-js');
+const { supabase } = require('../../src/lib/supabaseClient');
 
-if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
+if (!supabase) {
   console.error('Missing SUPABASE configuration');
   exports.handler = async () => ({
     statusCode: 500,
@@ -8,11 +8,6 @@ if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
   });
   return;
 }
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_KEY // Usa la Service Role Key para funciones backend
-);
 
 exports.handler = async (event) => {
   const ip =

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,9 +1,10 @@
 const { createClient } = require('@supabase/supabase-js');
 
-// Export a preconfigured Supabase client using env variables
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_KEY
-);
+// Prefer the service role key when available (for server-side usage)
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY;
+
+// Only create the client if configuration is present
+const supabase = url && key ? createClient(url, key) : null;
 
 module.exports = { supabase };

--- a/tests/vote.test.js
+++ b/tests/vote.test.js
@@ -4,7 +4,6 @@ let supabaseMock;
 
 const path = require('path');
 const fs = require('fs');
-const vm = require('vm');
 
 const loadHandler = () => {
   jest.resetModules();
@@ -13,8 +12,8 @@ const loadHandler = () => {
   const code = fs.readFileSync(path.join(__dirname, '../netlify/functions/vote.js'), 'utf8');
   const module = { exports: {} };
   const customRequire = (p) => {
-    if (p === '@supabase/supabase-js') {
-      return { createClient: globalThis.createClientMock };
+    if (p === '../../src/lib/supabaseClient') {
+      return { supabase: supabaseMock };
     }
     return require(p);
   };
@@ -26,7 +25,6 @@ const loadHandler = () => {
 describe('vote ip detection', () => {
   beforeEach(() => {
     jest.useFakeTimers().setSystemTime(new Date('2025-06-10T12:00:00Z'));
-    globalThis.createClientMock = jest.fn(() => supabaseMock);
     supabaseMock = {
       from: jest.fn(() => supabaseMock),
       select: jest.fn(() => supabaseMock),
@@ -37,7 +35,6 @@ describe('vote ip detection', () => {
       delete: jest.fn(() => Promise.resolve({ error: null })),
       single: jest.fn(() => Promise.resolve({ data: null, error: { code: 'PGRST116' } }))
     };
-    globalThis.createClientMock.mockReturnValue(supabaseMock);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- load Supabase credentials from environment variables
- use shared Supabase client in vote handler to avoid duplicate setup
- update tests to mock new centralized client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c912835c883238188bc993daaf0b0