### PR TITLE
Add mobile attendance longest streak stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -1565,6 +1565,66 @@
       return streak;
     }
 
+    function calculateLongestStreak(dates) {
+      if (!dates || !dates.length) return 0;
+
+      const sorted = dates
+        .map(d => parseLocalDate(d))
+        .filter(Boolean)
+        .sort((a, b) => a - b);
+
+      if (!sorted.length) return 0;
+
+      let longest = 1;
+      let current = 1;
+
+      for (let i = 1; i < sorted.length; i++) {
+        const diff = (sorted[i] - sorted[i - 1]) / (1000 * 60 * 60 * 24);
+
+        if (diff === 7) {
+          current += 1;
+        } else if (diff > 0) {
+          longest = Math.max(longest, current);
+          current = 1;
+        }
+      }
+
+      longest = Math.max(longest, current);
+      return longest;
+    }
+
+    function getStreakRankInfo(streak) {
+      if (streak > 20) {
+        return {
+          title: 'Cuadrillero Lomo dorado alpha',
+          background: 'linear-gradient(135deg, rgba(255, 215, 0, 0.25), rgba(255, 165, 0, 0.15))',
+          borderColor: 'rgba(255, 215, 0, 0.4)'
+        };
+      }
+      if (streak > 10) {
+        return {
+          title: 'Cuadrillero Lomo plateado',
+          background: 'linear-gradient(135deg, rgba(192, 192, 192, 0.25), rgba(255, 255, 255, 0.1))',
+          borderColor: 'rgba(192, 192, 192, 0.4)'
+        };
+      }
+      if (streak > 5) {
+        return {
+          title: 'Cuadrillero Lomo negro',
+          background: 'linear-gradient(135deg, rgba(26, 26, 26, 0.6), rgba(64, 64, 64, 0.3))',
+          borderColor: 'rgba(26, 26, 26, 0.7)'
+        };
+      }
+      if (streak > 2) {
+        return {
+          title: 'Cuadrillero Lomo rosado',
+          background: 'linear-gradient(135deg, rgba(255, 105, 180, 0.25), rgba(255, 182, 193, 0.15))',
+          borderColor: 'rgba(255, 105, 180, 0.4)'
+        };
+      }
+      return null;
+    }
+
     // ========== DATA LOADING ==========
     async function ensureUserProfile() {
       try {
@@ -2465,6 +2525,12 @@
         const lastAttendance = sortedAttendance[0];
         const attendedCount = sortedAttendance.length;
 
+        const attendanceDates = sortedAttendance
+          .map(item => item.semanas_cn?.fecha_martes)
+          .filter(Boolean);
+        const longestStreak = calculateLongestStreak(attendanceDates);
+        const streakRankInfo = getStreakRankInfo(longestStreak);
+
         let lastCNText = lastAttendance
           ? formatTuesdayDateLong(lastAttendance.semanas_cn.fecha_martes)
           : 'Nunca';
@@ -2504,7 +2570,17 @@
               <div style="font-weight: 500; margin-bottom: 4px;">📊 Promedio de tus votos por CN:</div>
               <div style="font-size: 0.9rem; color: #adb5bd;">${avgVotes}</div>
             </div>
+            <div style="background: rgba(255,255,255,0.05); border-radius: 6px; padding: 12px; margin-top: 8px;">
+              <div style="font-weight: 500; margin-bottom: 4px;">🔥 Tu longest streak:</div>
+              <div style="font-size: 0.9rem; color: #adb5bd;">${longestStreak > 0 ? `${longestStreak} CNs consecutivas` : 'N/A'}</div>
+            </div>
           </div>
+          ${streakRankInfo ? `
+            <div style="margin-top: 16px; padding: 16px; border-radius: 10px; border: 1px solid ${streakRankInfo.borderColor}; background: ${streakRankInfo.background};">
+              <div style="font-weight: 600; font-size: 1rem; color: #fff;">${streakRankInfo.title}</div>
+              <div style="font-size: 0.85rem; color: #e1e1e1; margin-top: 4px;">Tu racha más larga es de ${longestStreak} CNs consecutivas.</div>
+            </div>
+          ` : ''}
         `;
       } catch (err) {
         console.error('❌ Error loading user stats:', err);


### PR DESCRIPTION
## Summary
- add helpers to compute longest attendance streaks and derive streak rank metadata
- show the current user's longest streak and conditional rank card in the mobile attendance panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbb824bd308323ad92facb56804d06