### PR TITLE
Adjust streak level thresholds

### DIFF
--- a/index.html
+++ b/index.html
@@ -1600,55 +1600,55 @@
       const STREAK_LEVELS = [
         {
           id: 'nightmale',
-          min: 26,
+          min: 45,
           max: Infinity,
           title: '“NightmAle!” 👹🍺',
-          rangeText: '26+ CNs consecutivas',
+          rangeText: '45+ CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(111, 33, 255, 0.4), rgba(19, 22, 70, 0.65))',
           borderColor: 'rgba(111, 33, 255, 0.5)'
         },
         {
           id: 'ipa-insana',
-          min: 16,
-          max: 25,
+          min: 26,
+          max: 44,
           title: '“IPA Insana” 🌿💥',
-          rangeText: '16 - 25 CNs consecutivas',
+          rangeText: '26 - 44 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(0, 148, 94, 0.35), rgba(9, 64, 50, 0.6))',
           borderColor: 'rgba(0, 148, 94, 0.45)'
         },
         {
           id: 'stout-me-plenty',
-          min: 9,
-          max: 15,
+          min: 16,
+          max: 25,
           title: '“Stout Me Plenty” 🍫⚡',
-          rangeText: '9 - 15 CNs consecutivas',
+          rangeText: '16 - 25 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(94, 56, 19, 0.45), rgba(43, 26, 15, 0.65))',
           borderColor: 'rgba(94, 56, 19, 0.55)'
         },
         {
           id: 'hurt-me-pilsner',
-          min: 6,
-          max: 8,
+          min: 11,
+          max: 15,
           title: '“Hurt Me Pilsner” 🍺🔥',
-          rangeText: '6 - 8 CNs consecutivas',
+          rangeText: '11 - 15 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(255, 110, 64, 0.35), rgba(89, 32, 9, 0.55))',
           borderColor: 'rgba(255, 110, 64, 0.45)'
         },
         {
           id: 'happy-hour',
-          min: 4,
-          max: 5,
+          min: 6,
+          max: 10,
           title: '“Happy Hour” 🍻',
-          rangeText: '4 - 5 CNs consecutivas',
+          rangeText: '6 - 10 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(255, 187, 0, 0.28), rgba(133, 76, 0, 0.45))',
           borderColor: 'rgba(255, 187, 0, 0.4)'
         },
         {
           id: 'sed-principiante',
           min: 0,
-          max: 3,
+          max: 5,
           title: '“Sed de Principiante” 🍺',
-          rangeText: '0 - 3 CNs consecutivas',
+          rangeText: '0 - 5 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02))',
           borderColor: 'rgba(255, 255, 255, 0.18)'
         }


### PR DESCRIPTION
## Summary
- update streak level thresholds to make higher ranks harder to reach
- refresh displayed streak range text to match the new thresholds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbcaee27c0832388ae659d7285df25