### PR TITLE
Remove quotes from CN streak level titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1602,7 +1602,7 @@
           id: 'nightmale',
           min: 45,
           max: Infinity,
-          title: '“NightmAle!” 👹🍺',
+          title: 'NightmAle! 👹🍺',
           rangeText: '45+ CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(111, 33, 255, 0.4), rgba(19, 22, 70, 0.65))',
           borderColor: 'rgba(111, 33, 255, 0.5)'
@@ -1611,7 +1611,7 @@
           id: 'ipa-insana',
           min: 26,
           max: 44,
-          title: '“IPA Insana” 🌿💥',
+          title: 'IPA Insana 🌿💥',
           rangeText: '26 - 44 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(0, 148, 94, 0.35), rgba(9, 64, 50, 0.6))',
           borderColor: 'rgba(0, 148, 94, 0.45)'
@@ -1620,7 +1620,7 @@
           id: 'stout-me-plenty',
           min: 16,
           max: 25,
-          title: '“Stout Me Plenty” 🍫⚡',
+          title: 'Stout Me Plenty 🍫⚡',
           rangeText: '16 - 25 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(94, 56, 19, 0.45), rgba(43, 26, 15, 0.65))',
           borderColor: 'rgba(94, 56, 19, 0.55)'
@@ -1629,7 +1629,7 @@
           id: 'hurt-me-pilsner',
           min: 11,
           max: 15,
-          title: '“Hurt Me Pilsner” 🍺🔥',
+          title: 'Hurt Me Pilsner 🍺🔥',
           rangeText: '11 - 15 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(255, 110, 64, 0.35), rgba(89, 32, 9, 0.55))',
           borderColor: 'rgba(255, 110, 64, 0.45)'
@@ -1638,7 +1638,7 @@
           id: 'happy-hour',
           min: 6,
           max: 10,
-          title: '“Happy Hour” 🍻',
+          title: 'Happy Hour 🍻',
           rangeText: '6 - 10 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(255, 187, 0, 0.28), rgba(133, 76, 0, 0.45))',
           borderColor: 'rgba(255, 187, 0, 0.4)'
@@ -1647,7 +1647,7 @@
           id: 'sed-principiante',
           min: 0,
           max: 5,
-          title: '“Sed de Principiante” 🍺',
+          title: 'Sed de Principiante 🍺',
           rangeText: '0 - 5 CNs consecutivas',
           background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02))',
           borderColor: 'rgba(255, 255, 255, 0.18)'


### PR DESCRIPTION
## Summary
- remove leading and trailing quotes from the CN streak level titles so they render without extra punctuation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcbd1b704832395699d7ef2ead685