### PR TITLE
Fix asistencias update function

### DIFF
--- a/netlify/functions/updateAttendance.js
+++ b/netlify/functions/updateAttendance.js
@@ -1,54 +1,87 @@
 import { createClient } from '@supabase/supabase-js'
 
-const CORS = {
+const CORS_HEADERS = {
   'Access-Control-Allow-Origin': 'https://corkys.netlify.app',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
 }
 
+const jsonResponse = (statusCode, body) => ({
+  statusCode,
+  headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+})
+
+const buildErrorResponse = (error) => {
+  const message = String(error?.message || error || 'unknown error')
+  const normalized = message.toLowerCase()
+
+  const statusCode = /rls|policy|permission/.test(normalized)
+    ? 403
+    : /invalid|constraint|null value|violat/.test(normalized) || error?.status === 422 || error?.status === 400
+      ? 422
+      : error?.status && Number.isInteger(error.status)
+        ? error.status
+        : 500
+
+  if (statusCode === 500) {
+    console.error('UPDATE asistencias ERROR', { message })
+  } else {
+    console.warn('UPDATE asistencias WARNING', { statusCode, message })
+  }
+
+  return jsonResponse(statusCode, { error: message })
+}
+
 export const handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers: CORS, body: '' }
+    return { statusCode: 200, headers: CORS_HEADERS, body: '' }
   }
-  try {
-    const url = process.env.SUPABASE_URL
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY
-    console.log('ENV CHECK', { hasUrl: !!url, hasServiceRole: !!key })
-    if (!url || !key) {
-      return { statusCode: 500, headers: CORS, body: JSON.stringify({ error: 'misconfigured env' }) }
-    }
-    const supabase = createClient(url, key)
 
-    if (event.httpMethod !== 'POST') {
-      return { statusCode: 405, headers: CORS, body: JSON.stringify({ error: 'Method Not Allowed' }) }
-    }
-    let payload
-    try {
-      payload = event.body ? JSON.parse(event.body) : null
-    } catch {
-      return { statusCode: 422, headers: CORS, body: JSON.stringify({ error: 'Invalid JSON' }) }
-    }
-    const { week_id, fields } = payload || {}
-    if (!week_id || typeof fields !== 'object') {
-      return { statusCode: 422, headers: CORS, body: JSON.stringify({ error: 'Missing week_id or fields' }) }
-    }
+  const url = process.env.SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceRoleKey) {
+    console.error('Supabase env vars missing', { hasUrl: !!url, hasServiceRole: !!serviceRoleKey })
+    return jsonResponse(500, { error: 'misconfigured env' })
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return jsonResponse(405, { error: 'Method Not Allowed' })
+  }
+
+  let payload
+  try {
+    payload = event.body ? JSON.parse(event.body) : null
+  } catch (err) {
+    console.warn('Invalid JSON payload received')
+    return jsonResponse(422, { error: 'Invalid JSON' })
+  }
+
+  const wk = payload?.week_id ?? payload?.weekId ?? payload?.id ?? payload?.asistencia_id
+  const fields = payload?.fields ?? payload?.update ?? payload?.data
+
+  if (!wk || typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+    console.warn('Invalid payload', { hasWeek: !!wk, fieldsType: typeof fields })
+    return jsonResponse(422, { error: 'Missing week_id or fields' })
+  }
+
+  try {
+    const supabase = createClient(url, serviceRoleKey)
+
     const { data, error } = await supabase
-      .from('attendance')
+      .from('asistencias')
       .update(fields)
-      .eq('id', week_id)
+      .eq('id', wk)
       .select()
 
     if (error) {
-      const msg = String(error.message || error)
-      const status = /RLS|policy|permission/i.test(msg) ? 403
-                   : /invalid|constraint|null value|violates/i.test(msg) ? 422
-                   : 500
-      console.error('UPDATE ERROR', msg)
-      return { statusCode: status, headers: { ...CORS, 'Content-Type': 'application/json' }, body: JSON.stringify({ error: msg }) }
+      return buildErrorResponse(error)
     }
-    return { statusCode: 200, headers: { ...CORS, 'Content-Type': 'application/json' }, body: JSON.stringify({ ok: true, data }) }
-  } catch (e) {
-    console.error('HANDLER ERROR', e?.message)
-    return { statusCode: 500, headers: CORS, body: JSON.stringify({ error: e?.message || 'server error' }) }
+
+    return jsonResponse(200, { ok: true, data })
+  } catch (err) {
+    console.error('Unexpected handler failure', { message: err?.message })
+    return jsonResponse(500, { error: err?.message || 'server error' })
   }
 }

--- a/sql/20240215_admin_and_bares_policies.sql
+++ b/sql/20240215_admin_and_bares_policies.sql
@@ -7,18 +7,18 @@ as $$
   select coalesce(auth.email() in ('ahidalgod@gmail.com'), false);
 $$;
 
--- Attendance policies
-alter table public.attendance enable row level security;
+-- Asistencias policies
+alter table public.asistencias enable row level security;
 
-create policy if not exists "attendance update own"
-  on public.attendance
+create policy if not exists "asistencias update own"
+  on public.asistencias
   for update
   to authenticated
   using (user_id = auth.uid())
   with check (user_id = auth.uid());
 
-create policy if not exists "attendance admin can update all"
-  on public.attendance
+create policy if not exists "asistencias admin can update all"
+  on public.asistencias
   for update
   to authenticated
   using (public.is_admin())


### PR DESCRIPTION
## Summary
- refactor the Netlify `updateAttendance` function to target `public.asistencias`, accept backward-compatible payload aliases, and return JSON responses with unified CORS headers
- improve error handling by mapping Supabase constraint and RLS failures to 422/403 plus minimal logging, while keeping service-role env usage only
- update Supabase migration to enable/align asistencias row level policies with the helper admin function

## Tabla / PK
- La función asume que la PK de `public.asistencias` es `id` (como en la tabla `attendance`). Si difiere, actualizar la condición `.eq('<pk>', week_id)` en la función.

## Despliegue
1. Configurar `SUPABASE_URL` y `SUPABASE_SERVICE_ROLE_KEY` en el entorno de Netlify (o el que ejecute la Function).
2. Ejecutar/Aplicar `sql/20240215_admin_and_bares_policies.sql` en Supabase para habilitar las políticas de `public.asistencias`.
3. Redeploy de las Netlify Functions para publicar el handler actualizado.

## Network
- Ejecutar un POST desde la app (o `curl`) a `/.netlify/functions/updateAttendance` y capturar en DevTools la petición con respuesta HTTP 200 mostrando el JSON `{ ok: true, data: [...] }`. (No adjunto captura desde este entorno sin navegador.)

------
https://chatgpt.com/codex/tasks/task_e_68dbf9d26f6083239267b8954fa2b4f1