### PR TITLE
Update Netlify attendance function to target asistencias by ID

### DIFF
--- a/tests/updateAttendance.test.js
+++ b/tests/updateAttendance.test.js
@@ -1,261 +1,150 @@
 /** @jest-environment node */
 
-jest.mock('../netlify/lib/supabaseAdminClient', () => ({
-  getSupabaseAdminClient: jest.fn(),
-}));
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}))
 
-process.env.ALLOWED_ORIGINS = 'https://corkys.netlify.app, http://localhost:8888';
+const { createClient } = require('@supabase/supabase-js')
+const { handler } = require('../netlify/functions/updateAttendance.js')
 
-const { getSupabaseAdminClient } = require('../netlify/lib/supabaseAdminClient');
-const { handler } = require('../netlify/functions/updateAttendance');
+const buildSupabase = ({ selectResult, selectError } = {}) => {
+  const selectMock = jest.fn()
+  if (selectError) {
+    selectMock.mockRejectedValue(selectError)
+  } else {
+    selectMock.mockResolvedValue(selectResult ?? { data: [{ id: 10 }], error: null })
+  }
 
-const buildSupabaseMock = ({ semanasCn = {}, asistencias = {}, visitasBares = {} } = {}) => ({
-  from: jest.fn((table) => {
-    if (table === 'semanas_cn') {
-      return {
-        select: jest.fn(() => ({
-          eq: jest.fn(() => ({
-            maybeSingle: jest.fn(() =>
-              Promise.resolve(
-                semanasCn.maybeSingle ? semanasCn.maybeSingle() : { data: { id: 1 }, error: null },
-              ),
-            ),
-          })),
-        })),
-        update: jest.fn((values) => {
-          if (semanasCn.updateSpy) semanasCn.updateSpy(values);
-          const resultFactory = semanasCn.updateResult || (() => ({ data: null, error: null }));
-          return {
-            eq: jest.fn(() => Promise.resolve(resultFactory())),
-          };
-        }),
-      };
+  const eqMock = jest.fn(() => ({ select: selectMock }))
+  const updateMock = jest.fn(() => ({ eq: eqMock }))
+  const fromMock = jest.fn((table) => {
+    if (table !== 'asistencias') {
+      throw new Error(`Unexpected table: ${table}`)
     }
+    return { update: updateMock }
+  })
 
-    if (table === 'asistencias') {
-      return {
-        delete: jest.fn(() => {
-          if (asistencias.deleteSpy) asistencias.deleteSpy();
-          const resultFactory = asistencias.deleteResult || (() => ({ data: null, error: null }));
-          return {
-            eq: jest.fn(() => Promise.resolve(resultFactory())),
-          };
-        }),
-        insert: jest.fn((values) => {
-          if (asistencias.insertSpy) asistencias.insertSpy(values);
-          const resultFactory = asistencias.insertResult || (() => ({ data: null, error: null }));
-          return Promise.resolve(resultFactory());
-        }),
-      };
-    }
+  createClient.mockReturnValue({ from: fromMock })
 
-    if (table === 'visitas_bares') {
-      return {
-        upsert: jest.fn((values, options) => {
-          if (visitasBares.upsertSpy) visitasBares.upsertSpy(values, options);
-          const resultFactory = visitasBares.upsertResult || (() => ({ data: null, error: null }));
-          return Promise.resolve(resultFactory());
-        }),
-      };
-    }
-
-    throw new Error(`Unexpected table: ${table}`);
-  }),
-});
+  return { selectMock, eqMock, updateMock, fromMock }
+}
 
 describe('updateAttendance handler', () => {
+  const ORIGINAL_URL = process.env.SUPABASE_URL
+  const ORIGINAL_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+
   beforeEach(() => {
-    jest.clearAllMocks();
-  });
+    jest.clearAllMocks()
+    process.env.SUPABASE_URL = 'https://test.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role'
+  })
 
-  test('successful update with valid data', async () => {
-    const updateSpy = jest.fn(() => ({ data: null, error: null }));
-    const deleteSpy = jest.fn(() => ({ data: null, error: null }));
-    const insertSpy = jest.fn(() => ({ data: null, error: null }));
-    const upsertSpy = jest.fn(() => ({ data: null, error: null }));
+  afterAll(() => {
+    if (ORIGINAL_URL) {
+      process.env.SUPABASE_URL = ORIGINAL_URL
+    } else {
+      delete process.env.SUPABASE_URL
+    }
 
-    const supabaseMock = buildSupabaseMock({
-      semanasCn: {
-        maybeSingle: () => ({ data: { id: 1 }, error: null }),
-        updateSpy,
-      },
-      asistencias: {
-        deleteSpy,
-        insertSpy,
-      },
-      visitasBares: {
-        upsertSpy,
-      },
-    });
+    if (ORIGINAL_KEY) {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = ORIGINAL_KEY
+    } else {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    }
+  })
 
-    getSupabaseAdminClient.mockReturnValue(supabaseMock);
+  test('responds to OPTIONS with CORS headers', async () => {
+    const response = await handler({ httpMethod: 'OPTIONS' })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['Access-Control-Allow-Origin']).toBe('https://corkys.netlify.app')
+    expect(response.headers['Content-Type']).toBe('application/json')
+    expect(createClient).not.toHaveBeenCalled()
+  })
 
-    const response = await handler({
-      httpMethod: 'POST',
-      body: JSON.stringify({ weekId: 12, bar: 'Bar Azul', attendees: ['u1', 'u2'] }),
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
+  test('returns 405 for non-POST methods', async () => {
+    const response = await handler({ httpMethod: 'GET' })
+    expect(response.statusCode).toBe(405)
+    expect(JSON.parse(response.body).error).toBe('Method Not Allowed')
+    expect(createClient).not.toHaveBeenCalled()
+  })
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['Access-Control-Allow-Origin']).toBe('https://corkys.netlify.app');
-    const payload = JSON.parse(response.body);
-    expect(payload.data).toEqual({
-      weekId: 12,
-      bar: 'Bar Azul',
-      attendees: ['u1', 'u2'],
-      totalAttendees: 2,
-    });
+  test('returns 422 for invalid JSON payload', async () => {
+    const response = await handler({ httpMethod: 'POST', body: '{ invalid' })
+    expect(response.statusCode).toBe(422)
+    expect(JSON.parse(response.body).error).toBe('Invalid JSON')
+    expect(createClient).not.toHaveBeenCalled()
+  })
 
-    expect(updateSpy).toHaveBeenCalledWith({
-      bar_ganador: 'Bar Azul',
-      total_asistentes: 2,
-      hubo_quorum: false,
-    });
-    expect(deleteSpy).toHaveBeenCalled();
-    expect(insertSpy).toHaveBeenCalledWith([
-      { user_id: 'u1', semana_id: 12, confirmado: true },
-      { user_id: 'u2', semana_id: 12, confirmado: true },
-    ]);
-    expect(upsertSpy).toHaveBeenCalledWith([{ bar: 'Bar Azul', semana_id: 12 }], { onConflict: 'bar' });
-  });
+  test('returns 422 when week_id or fields are missing', async () => {
+    const response = await handler({ httpMethod: 'POST', body: JSON.stringify({}) })
+    expect(response.statusCode).toBe(422)
+    expect(JSON.parse(response.body).error).toBe('Missing week_id or fields')
+    expect(createClient).not.toHaveBeenCalled()
+  })
 
-  test('returns 422 on invalid JSON', async () => {
-    const response = await handler({
-      httpMethod: 'POST',
-      body: '{ invalid',
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
-    expect(response.statusCode).toBe(422);
-    expect(JSON.parse(response.body).error).toBe('Invalid JSON payload');
-    expect(response.headers['Access-Control-Allow-Origin']).toBe('https://corkys.netlify.app');
-  });
+  test('updates asistencias row using primary key', async () => {
+    const { selectMock, eqMock, updateMock, fromMock } = buildSupabase()
+    const payload = { week_id: 42, fields: { bar_id: 5, asistentes: 10 } }
+    const response = await handler({ httpMethod: 'POST', body: JSON.stringify(payload) })
 
-  test('returns 422 when weekId is missing', async () => {
-    const response = await handler({
-      httpMethod: 'POST',
-      body: JSON.stringify({ attendees: [] }),
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
+    expect(createClient).toHaveBeenCalled()
+    expect(fromMock).toHaveBeenCalledWith('asistencias')
+    expect(updateMock).toHaveBeenCalledWith({ bar_id: 5, asistentes: 10 })
+    expect(eqMock).toHaveBeenCalledWith('id', 42)
+    expect(selectMock).toHaveBeenCalled()
 
-    expect(response.statusCode).toBe(422);
-    expect(JSON.parse(response.body).error).toBe('Invalid payload: weekId is required');
-  });
+    expect(response.statusCode).toBe(200)
+    const body = JSON.parse(response.body)
+    expect(body.ok).toBe(true)
+    expect(body.data).toEqual([{ id: 10 }])
+  })
 
-  test('returns 422 when attendees is not an array', async () => {
-    const response = await handler({
-      httpMethod: 'POST',
-      body: JSON.stringify({ weekId: 1, attendees: 'nope' }),
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
+  test('accepts legacy aliases for payload keys', async () => {
+    const { eqMock, updateMock } = buildSupabase()
+    const payload = { weekId: 99, update: { asistentes: 3 } }
+    const response = await handler({ httpMethod: 'POST', body: JSON.stringify(payload) })
 
-    expect(response.statusCode).toBe(422);
-    expect(JSON.parse(response.body).error).toBe('Invalid payload: attendees must be an array of user IDs');
-  });
+    expect(updateMock).toHaveBeenCalledWith({ asistentes: 3 })
+    expect(eqMock).toHaveBeenCalledWith('id', 99)
+    expect(response.statusCode).toBe(200)
+  })
 
-  test('returns 404 when week does not exist', async () => {
-    const supabaseMock = buildSupabaseMock({
-      semanasCn: {
-        maybeSingle: () => ({ data: null, error: null }),
-      },
-    });
-    getSupabaseAdminClient.mockReturnValue(supabaseMock);
+  test('maps constraint errors to 422', async () => {
+    buildSupabase({ selectResult: { data: null, error: { message: 'violates unique constraint', status: 400 } } })
+    const payload = { week_id: 5, fields: { asistentes: 1 } }
+    const response = await handler({ httpMethod: 'POST', body: JSON.stringify(payload) })
 
-    const response = await handler({
-      httpMethod: 'POST',
-      body: JSON.stringify({ weekId: 33, attendees: [] }),
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
+    expect(response.statusCode).toBe(422)
+    expect(JSON.parse(response.body).error).toContain('violates unique constraint')
+  })
 
-    expect(response.statusCode).toBe(404);
-    expect(JSON.parse(response.body).error).toBe('Week 33 not found');
-    expect(response.headers['Access-Control-Allow-Origin']).toBe('https://corkys.netlify.app');
-  });
+  test('maps policy errors to 403', async () => {
+    buildSupabase({ selectResult: { data: null, error: { message: 'permission denied for policy "asistencias"', status: 401 } } })
+    const payload = { week_id: 7, fields: { asistentes: 1 } }
+    const response = await handler({ httpMethod: 'POST', body: JSON.stringify(payload) })
 
-  test('propagates Supabase errors with status code', async () => {
-    const supabaseError = Object.assign(new Error('boom'), { status: 409 });
-    const supabaseMock = buildSupabaseMock({
-      semanasCn: {
-        maybeSingle: () => ({ data: { id: 5 }, error: null }),
-        updateResult: () => ({ data: null, error: supabaseError }),
-      },
-      asistencias: {
-        deleteResult: () => ({ data: null, error: null }),
-      },
-    });
+    expect(response.statusCode).toBe(403)
+    expect(JSON.parse(response.body).error).toContain('permission denied')
+  })
 
-    getSupabaseAdminClient.mockReturnValue(supabaseMock);
+  test('returns 500 on unexpected Supabase failure', async () => {
+    buildSupabase({ selectError: new Error('network down') })
+    const payload = { week_id: 8, fields: { asistentes: 4 } }
+    const response = await handler({ httpMethod: 'POST', body: JSON.stringify(payload) })
 
-    const response = await handler({
-      httpMethod: 'POST',
-      body: JSON.stringify({ weekId: 5, attendees: [] }),
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
+    expect(response.statusCode).toBe(500)
+    expect(JSON.parse(response.body).error).toBe('network down')
+  })
 
-    expect(response.statusCode).toBe(409);
-    expect(JSON.parse(response.body).error).toBe('boom');
-    expect(response.headers['Access-Control-Allow-Origin']).toBe('https://corkys.netlify.app');
-  });
+  test('returns 500 when env vars are missing', async () => {
+    delete process.env.SUPABASE_URL
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
 
-  test('responds to OPTIONS preflight with CORS headers', async () => {
-    const response = await handler({
-      httpMethod: 'OPTIONS',
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
+    const payload = { week_id: 3, fields: { asistentes: 2 } }
+    const response = await handler({ httpMethod: 'POST', body: JSON.stringify(payload) })
 
-    expect(response.statusCode).toBe(204);
-    expect(response.body).toBe('');
-    expect(response.headers['Access-Control-Allow-Origin']).toBe('https://corkys.netlify.app');
-    expect(response.headers['Access-Control-Allow-Methods']).toContain('OPTIONS');
-    expect(response.headers['Access-Control-Allow-Headers']).toContain('authorization');
-  });
-
-  test('maps supabase bad request errors to 422', async () => {
-    const supabaseError = Object.assign(new Error('invalid input'), { status: 400 });
-
-    const supabaseMock = buildSupabaseMock({
-      semanasCn: {
-        maybeSingle: () => ({ data: { id: 2 }, error: null }),
-        updateResult: () => ({ data: null, error: supabaseError }),
-      },
-      asistencias: {
-        deleteResult: () => ({ data: null, error: null }),
-      },
-    });
-
-    getSupabaseAdminClient.mockReturnValue(supabaseMock);
-
-    const response = await handler({
-      httpMethod: 'POST',
-      body: JSON.stringify({ weekId: 2, attendees: [] }),
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
-
-    expect(response.statusCode).toBe(422);
-    expect(JSON.parse(response.body).error).toBe('invalid input');
-  });
-
-  test('bubbles up authorization errors as 403', async () => {
-    const supabaseError = Object.assign(new Error('permission denied'), { status: 403 });
-
-    const supabaseMock = buildSupabaseMock({
-      semanasCn: {
-        maybeSingle: () => ({ data: { id: 3 }, error: null }),
-        updateResult: () => ({ data: null, error: supabaseError }),
-      },
-      asistencias: {
-        deleteResult: () => ({ data: null, error: null }),
-      },
-    });
-
-    getSupabaseAdminClient.mockReturnValue(supabaseMock);
-
-    const response = await handler({
-      httpMethod: 'POST',
-      body: JSON.stringify({ weekId: 3, attendees: [] }),
-      headers: { origin: 'https://corkys.netlify.app' },
-    });
-
-    expect(response.statusCode).toBe(403);
-    expect(JSON.parse(response.body).error).toBe('permission denied');
-  });
-});
+    expect(response.statusCode).toBe(500)
+    expect(JSON.parse(response.body).error).toBe('misconfigured env')
+    expect(createClient).not.toHaveBeenCalled()
+  })
+})

--- a/tests/weekEdit.test.js
+++ b/tests/weekEdit.test.js
@@ -57,7 +57,6 @@ describe('saveWeekChanges', () => {
           fields: {
             bar_id: 3,
             asistentes: 5,
-            attendees: ['u1']
           }
         })
       })

--- a/weekEdit.js
+++ b/weekEdit.js
@@ -152,40 +152,52 @@ async function saveWeekChanges() {
     return;
   }
 
-  const normalizeId = (value) => {
-    if (value === undefined || value === null || value === '') return null;
-    const num = Number(value);
-    return Number.isNaN(num) || num <= 0 ? null : num;
-  };
+  const week_id = Number(modalEl.dataset?.weekId);
 
-  const datasetWeekId = modalEl.dataset?.weekId;
-  const weekIdFromDataset = normalizeId(datasetWeekId);
-  const weekIdFromState = normalizeId(editingWeekId);
-  const week_id = weekIdFromDataset || weekIdFromState;
+  if (!Number.isFinite(week_id) || week_id <= 0) {
+    alert('Faltan datos: week_id o fields');
+    return;
+  }
 
   const barSelect = modalEl?.querySelector('#editBarSelect');
   const asistentesInput = modalEl?.querySelector('#editAsistentes');
-  const selected = Array.from(
-    modalEl.querySelectorAll('#editWeekUsers input:checked')
-  ).map(el => el.value);
+  const selectedCount = modalEl ? modalEl.querySelectorAll('#editWeekUsers input:checked').length : 0;
 
-  const barId = barSelect && barSelect.value !== '' ? Number(barSelect.value) : null;
-  const asistentesRaw = asistentesInput ? asistentesInput.value.trim() : '';
-  const asistentesNumber = asistentesRaw === '' ? selected.length : Number(asistentesRaw);
-  const asistentes = Number.isNaN(asistentesNumber) ? selected.length : asistentesNumber;
+  let bar_id = null;
+  if (barSelect) {
+    const rawBar = barSelect.value;
+    if (rawBar !== '') {
+      const parsedBar = Number(rawBar);
+      if (Number.isNaN(parsedBar)) {
+        alert('El bar seleccionado es inválido');
+        return;
+      }
+      bar_id = parsedBar;
+    }
+  }
 
-  const attendees = selected.map((value) => {
-    const numeric = Number(value);
-    return Number.isNaN(numeric) ? value : numeric;
-  });
+  let asistentes;
+  if (asistentesInput) {
+    const rawAsistentes = asistentesInput.value.trim();
+    if (rawAsistentes === '') {
+      asistentes = selectedCount;
+    } else {
+      const parsedAsistentes = Number(rawAsistentes);
+      if (Number.isNaN(parsedAsistentes) || parsedAsistentes < 0) {
+        alert('El total de asistentes es inválido');
+        return;
+      }
+      asistentes = parsedAsistentes;
+    }
+  } else {
+    asistentes = selectedCount;
+  }
 
-  const fields = {
-    bar_id: barId !== null && !Number.isNaN(barId) ? barId : null,
-    asistentes,
-    attendees,
-  };
+  const fields = {};
+  fields.bar_id = bar_id;
+  fields.asistentes = asistentes;
 
-  if (!week_id || !fields || typeof fields !== 'object') {
+  if (!fields || typeof fields !== 'object') {
     alert('Faltan datos: week_id o fields');
     return;
   }


### PR DESCRIPTION
## Summary
- update the Netlify `updateAttendance` function to log diagnostics, honour payload aliases, and update `asistencias` rows by primary key while keeping CORS responses consistent
- adjust the admin modal save handler to read the modal dataset ID and send numeric `bar_id`/`asistentes` values in the `fields` payload
- refresh Jest coverage to reflect the new handler contract and payload structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbfd0d7ae083238140e1c1a7941878