### PR TITLE
Switch attendance updates to PostgREST

### DIFF
--- a/tests/weekEdit.test.js
+++ b/tests/weekEdit.test.js
@@ -8,10 +8,9 @@ describe('saveWeekChanges', () => {
     document.body.innerHTML = `
       <div id="editWeekModal" data-week-id="1">
         <select id="editBarSelect"><option value="3">Bar1</option></select>
-        <input id="editAsistentes" type="number" value="5" />
         <div id="editWeekUsers">
-          <input type="checkbox" value="u1" checked>
-          <input type="checkbox" value="u2">
+          <input class="chk-usuario" type="checkbox" value="u1" checked>
+          <input class="chk-usuario" type="checkbox" value="u2">
         </div>
       </div>
     `;
@@ -26,7 +25,7 @@ describe('saveWeekChanges', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ success: true })
+        text: () => Promise.resolve(JSON.stringify({ ok: true })),
       })
     );
 
@@ -54,10 +53,9 @@ describe('saveWeekChanges', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           week_id: 1,
-          fields: {
-            bar_id: 3,
-            asistentes: 5,
-          }
+          bar_id: 3,
+          add_user_ids: ['u1'],
+          recompute_total: true,
         })
       })
     );
@@ -70,7 +68,7 @@ describe('saveWeekChanges', () => {
     global.fetch.mockResolvedValueOnce({
       ok: false,
       status: 400,
-      json: () => Promise.resolve({ error: 'Bad request' }),
+      text: () => Promise.resolve('Bad request'),
     });
 
     await saveWeekChanges();

--- a/weekEdit.js
+++ b/weekEdit.js
@@ -112,7 +112,7 @@ async function openEditWeek(weekId) {
     const usersContainer = document.getElementById('editWeekUsers');
     usersContainer.innerHTML = (usersRes.data || []).map(u => `
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" value="${u.id}" id="editUser-${u.id}" ${attendees.has(u.id) ? 'checked' : ''}>
+        <input class="form-check-input chk-usuario" type="checkbox" value="${u.id}" id="editUser-${u.id}" ${attendees.has(u.id) ? 'checked' : ''}>
         <label class="form-check-label" for="editUser-${u.id}">${u.nombre}</label>
       </div>
     `).join('');
@@ -159,50 +159,14 @@ async function saveWeekChanges() {
     return;
   }
 
-  const barSelect = modalEl?.querySelector('#editBarSelect');
-  const asistentesInput = modalEl?.querySelector('#editAsistentes');
-  const selectedCount = modalEl ? modalEl.querySelectorAll('#editWeekUsers input:checked').length : 0;
+  const barSelect = document.getElementById('editBarSelect');
+  const bar_id = barSelect ? Number(barSelect.value) || null : null;
 
-  let bar_id = null;
-  if (barSelect) {
-    const rawBar = barSelect.value;
-    if (rawBar !== '') {
-      const parsedBar = Number(rawBar);
-      if (Number.isNaN(parsedBar)) {
-        alert('El bar seleccionado es inválido');
-        return;
-      }
-      bar_id = parsedBar;
-    }
-  }
+  const add_user_ids = Array.from(document.querySelectorAll('.chk-usuario:checked')).map((el) => el.value);
 
-  let asistentes;
-  if (asistentesInput) {
-    const rawAsistentes = asistentesInput.value.trim();
-    if (rawAsistentes === '') {
-      asistentes = selectedCount;
-    } else {
-      const parsedAsistentes = Number(rawAsistentes);
-      if (Number.isNaN(parsedAsistentes) || parsedAsistentes < 0) {
-        alert('El total de asistentes es inválido');
-        return;
-      }
-      asistentes = parsedAsistentes;
-    }
-  } else {
-    asistentes = selectedCount;
-  }
+  const payload = { week_id, bar_id, add_user_ids, recompute_total: true };
 
-  const fields = {};
-  fields.bar_id = bar_id;
-  fields.asistentes = asistentes;
-
-  if (!fields || typeof fields !== 'object') {
-    alert('Faltan datos: week_id o fields');
-    return;
-  }
-
-  const payload = { week_id, fields };
+  console.log('REQUEST updateAttendance', payload);
 
   if (typeof isAdmin !== 'undefined' && !isAdmin) {
     return;
@@ -215,9 +179,9 @@ async function saveWeekChanges() {
       body: JSON.stringify(payload),
     });
 
-    const data = await res.json();
+    const txt = await res.text();
     if (!res.ok) {
-      throw new Error(`${res.status}: ${data.error || 'Request failed'}`);
+      throw new Error(`${res.status}: ${txt}`);
     }
 
     const modalInstance = bootstrap.Modal.getInstance(modalEl);


### PR DESCRIPTION
## Summary
- replace the Netlify `updateAttendance` function with a PostgREST-based implementation that updates the winning bar, inserts confirmed attendees, and optionally recomputes totals with consistent CORS/error handling
- adjust the admin modal to send the new payload structure and mark attendee checkboxes, plus document the API contract in the README
- refresh the Jest suites to cover the new backend flow and frontend request payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcd42014088323beb6dd8736f1505e