### PR TITLE
Fix updateAttendance Netlify function for Supabase operations

### DIFF
--- a/netlify/functions/updateAttendance.ts
+++ b/netlify/functions/updateAttendance.ts
@@ -8,96 +8,98 @@ const urlBase = (process.env.SUPABASE_URL || '').trim().replace(/\/+$/, '');
 const serviceKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
 
 export const handler = async (event: any) => {
-  if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers: CORS, body: '' };
-  }
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: CORS, body: '' };
+
   try {
     if (!/^https:\/\//.test(urlBase) || !serviceKey) {
-      return resp(500, { error: 'misconfigured env' });
+      return json(500, { error: 'misconfigured env' });
     }
 
     let payload: any = {};
     try {
       payload = event.body ? JSON.parse(event.body) : {};
     } catch {
-      return resp(422, { error: 'Invalid JSON' });
+      return json(422, { error: 'Invalid JSON' });
     }
 
-    // Payload esperado (acepta alias por compat):
-    // week_id (required), bar_id OR bar_nombre (opcional),
-    // add_user_ids: string[] (optional), recompute_total: boolean (optional)
     const week_id = payload.week_id ?? payload.weekId ?? payload.id;
-    const bar_id = payload.bar_id ?? payload.barId;
-    let bar_nombre = payload.bar_nombre ?? payload.barNombre ?? payload.bar;
+    const bar_id = payload.bar_id ?? payload.barId ?? null;
+    let bar_nombre = payload.bar_nombre ?? payload.barNombre ?? payload.bar ?? null;
     const add_user_ids: string[] = payload.add_user_ids ?? payload.user_ids ?? [];
     const recompute_total = !!payload.recompute_total;
 
-    if (!week_id) return resp(422, { error: 'Missing week_id' });
+    if (!week_id) return json(422, { error: 'Missing week_id' });
 
-    // 1) Resolver bar_nombre si sólo vino bar_id
-    if (!bar_nombre && bar_id) {
-      const r = await pgGetOne('bares', `id=eq.${Number(bar_id)}`, 'nombre');
+    const weekIdNum = Number(week_id);
+    if (!Number.isFinite(weekIdNum)) return json(422, { error: 'Invalid week_id' });
+
+    const barIdNum = bar_id != null ? Number(bar_id) : null;
+    if (barIdNum != null && !Number.isFinite(barIdNum)) return json(422, { error: 'Invalid bar_id' });
+
+    // Resolver bar_nombre si sólo viene bar_id
+    if (!bar_nombre && barIdNum != null) {
+      const r = await pgGet(`bares?id=eq.${barIdNum}&select=nombre&limit=1`);
       if (!r.ok) return proxy(r);
-      bar_nombre = (await r.json())[0]?.nombre;
-      if (!bar_nombre) return resp(422, { error: 'bar_id not found' });
+      const data = await r.json();
+      bar_nombre = data?.[0]?.nombre || null;
+      if (!bar_nombre) return json(422, { error: 'bar_id not found' });
     }
 
-    // 2) Actualizar bar_ganador si hay bar_nombre
+    // 1) Actualizar bar_ganador en semanas_cn
     if (bar_nombre) {
-      const up = await pgPatch('semanas_cn', `id=eq.${Number(week_id)}`, { bar_ganador: bar_nombre });
-      if (!up.ok) return proxy(up);
+      const up1 = await pgPatch('semanas_cn', `id=eq.${weekIdNum}`, { bar_ganador: bar_nombre });
+      if (!up1.ok) return proxy(up1);
+
+      // 1b) Reflejar en visitas_bares
+      const up2 = await pgPatch('visitas_bares', `semana_id=eq.${weekIdNum}`, { bar: bar_nombre });
+      if (!up2.ok && ![404, 406].includes(up2.status)) return proxy(up2);
     }
 
-    // 3) Insertar asistentes si vienen user_ids
+    // 2) Insertar asistencias
     if (Array.isArray(add_user_ids) && add_user_ids.length > 0) {
-      const rows = add_user_ids.map((uid) => ({
+      const rows = add_user_ids.map((uid: string) => ({
         user_id: uid,
-        semana_id: Number(week_id),
+        semana_id: weekIdNum,
         confirmado: true,
         created_at: new Date().toISOString(),
       }));
-      const ins = await pgInsert('asistencias', rows, 'ignore'); // usa ON CONFLICT DO NOTHING
+      const ins = await pgInsert('asistencias', rows, true);
       if (!ins.ok) return proxy(ins);
     }
 
-    // 4) Recalcular total_asistentes (si la columna existe y flag on)
+    // 3) Recalcular total de asistentes (si aplica)
     if (recompute_total) {
-      const c = await pgGet('asistencias', `semana_id=eq.${Number(week_id)}`, 'select=id');
-      if (!c.ok) return proxy(c);
-      const total = Number(c.headers.get('content-range')?.split('/')?.[1] || 0);
-
-      // intenta varias columnas posibles; si ninguna existe, ignora
-      const tryCols = ['total_asistentes', 'total_asistertes', 'total_asist', 'total_asistentes_cn'];
-      for (const col of tryCols) {
-        const upd = await pgPatch('semanas_cn', `id=eq.${Number(week_id)}`, { [col]: total });
+      const cntRes = await pgGet(`asistencias?semana_id=eq.${weekIdNum}`, 'count=exact');
+      if (!cntRes.ok) return proxy(cntRes);
+      const range = cntRes.headers.get('content-range') || '';
+      const total = Number(range.split('/')?.[1] || 0);
+      const candidates = ['total_asistentes', 'total_asist', 'total_asistertes'];
+      for (const col of candidates) {
+        const upd = await pgPatch('semanas_cn', `id=eq.${weekIdNum}`, { [col]: total });
         if (upd.ok) break;
       }
     }
 
-    return resp(200, { ok: true });
+    return json(200, { ok: true });
   } catch (e: any) {
     console.error('HANDLER ERROR', e?.message);
-    return resp(500, { error: e?.message || 'server error' });
+    return json(500, { error: e?.message || 'server error' });
   }
 };
 
-function resp(status: number, body: any) {
-  return {
-    statusCode: status,
-    headers: { ...CORS, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  };
+function json(status: number, body: any) {
+  return { statusCode: status, headers: { ...CORS, 'Content-Type': 'application/json' }, body: JSON.stringify(body) };
 }
 
 async function proxy(r: any) {
-  let text: string | undefined;
+  let text = '';
   try {
     text = await r.text();
   } catch (err: any) {
-    text = err?.message;
+    text = err?.message || '';
   }
 
-  let body: any = undefined;
+  let body: any;
   if (text) {
     try {
       body = JSON.parse(text);
@@ -105,18 +107,23 @@ async function proxy(r: any) {
       body = { error: text };
     }
   }
-
-  if (!body || typeof body !== 'object') {
-    body = { error: r.statusText || 'request failed' };
-  } else if (!body.error && text) {
-    body.error = text;
+  const message = body?.message || body?.error || text || r.statusText || 'request failed';
+  if (r.status === 401 || r.status === 403) {
+    return json(403, { error: message });
   }
-
-  return resp(r.status || 500, body);
+  if ([400, 404, 406, 409, 422].includes(r.status)) {
+    return json(422, { error: message });
+  }
+  return json(500, { error: message });
 }
 
-// --- PostgREST helpers ---
-async function pgPatch(table: string, filter: string, data: any) {
+async function pgGet(pathQS: string, extraPrefer: string = '') {
+  const headers: Record<string, string> = { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` };
+  if (extraPrefer) headers.Prefer = extraPrefer;
+  return fetch(`${urlBase}/rest/v1/${pathQS}`, { method: 'GET', headers });
+}
+
+async function pgPatch(table: string, filter: string, body: any) {
   return fetch(`${urlBase}/rest/v1/${table}?${filter}`, {
     method: 'PATCH',
     headers: {
@@ -125,36 +132,17 @@ async function pgPatch(table: string, filter: string, data: any) {
       'Content-Type': 'application/json',
       Prefer: 'return=representation',
     },
-    body: JSON.stringify(data),
+    body: JSON.stringify(body),
   });
 }
 
-async function pgInsert(table: string, rows: any[], onConflict: 'ignore' | 'error' = 'error') {
+async function pgInsert(table: string, rows: any[], ignoreDuplicates = false) {
   const headers: Record<string, string> = {
     apikey: serviceKey,
     Authorization: `Bearer ${serviceKey}`,
     'Content-Type': 'application/json',
     Prefer: 'return=minimal',
   };
-  if (onConflict === 'ignore') headers.Prefer += ',resolution=ignore-duplicates';
-  return fetch(`${urlBase}/rest/v1/${table}`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(rows),
-  });
-}
-
-async function pgGetOne(table: string, filter: string, select: string) {
-  return fetch(`${urlBase}/rest/v1/${table}?${filter}&select=${encodeURIComponent(select)}&limit=1`, {
-    method: 'GET',
-    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
-  });
-}
-
-async function pgGet(table: string, filter: string, extraQuery: string = '') {
-  const qs = `${filter}${extraQuery ? `&${extraQuery}` : ''}`;
-  return fetch(`${urlBase}/rest/v1/${table}?${qs}`, {
-    method: 'GET',
-    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}`, Prefer: 'count=exact' },
-  });
+  if (ignoreDuplicates) headers.Prefer += ',resolution=ignore-duplicates';
+  return fetch(`${urlBase}/rest/v1/${table}`, { method: 'POST', headers, body: JSON.stringify(rows) });
 }


### PR DESCRIPTION
## Summary
- rewrite the Netlify updateAttendance function to sanitize environment configuration and normalize incoming payload aliases
- update winning bar and visitas_bares records, upsert attendance rows, and optionally recompute weekly totals through PostgREST
- unify CORS handling and error mapping to always return structured JSON responses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcdfd91adc83239b59ce3b6647c639