### PR TITLE
Remove desktop edit option from last visits table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1032,13 +1032,6 @@
       color: var(--color-accent);
     }
 
-    .edit-week-btn {
-      margin-left: 8px;
-    }
-
-    @media (max-width: 768px) {
-      .edit-week-btn { display: none !important; }
-    }
   </style>
 </head>
 <body>
@@ -3131,7 +3124,6 @@
                 <div class="d-flex justify-content-between align-items-center py-1">
                   <span>${bar.name}</span>
                   <span class="${visitClass}">${visitText}</span>
-                  ${isAdmin && bar.weekId ? `<button class="btn btn-sm btn-outline-info edit-week-btn" onclick="openEditWeek(${bar.weekId})">Editar</button>` : ''}
                 </div>`;
             }).join('');
           }


### PR DESCRIPTION
## Summary
- remove the admin edit button from the desktop "Última Vez que Ganó" stats list to prevent editing weeks
- clean up the unused CSS for the removed edit button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcff3db4708323a02695673d0bcc15