### PR TITLE
Show quorum status in history views

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -438,7 +438,7 @@
                   ${week.estado}
                 </span>
               </td>
-              <td>${week.bar_ganador || '-'}</td>
+              <td>${week.hubo_quorum ? (week.bar_ganador || '—') : 'Sin quorum'}</td>
               <td>${week.total_votos || 0}</td>
               <td>${week.total_asistentes || 0}</td>
               <td>${week.hubo_quorum ? '✅' : '❌'}</td>

--- a/index.html
+++ b/index.html
@@ -3826,8 +3826,15 @@
     function formatWeekEditorLabel(week) {
       if (!week) return 'Semana';
       const dateText = formatTuesdayDateLong(week.fecha_martes);
-      const barText = week.bar_ganador ? ` – ${week.bar_ganador}` : '';
-      return `${dateText}${barText}`;
+      let detailText = '';
+
+      if (week.hubo_quorum === false) {
+        detailText = ' – Sin quorum';
+      } else if (week.bar_ganador) {
+        detailText = ` – ${week.bar_ganador}`;
+      }
+
+      return `${dateText}${detailText}`;
     }
 
     function showWeekEditorFeedback(message, type = 'info') {
@@ -4008,16 +4015,19 @@
         return;
       }
 
-      tbody.innerHTML = weekEditorWeeks.map(week => `
+      tbody.innerHTML = weekEditorWeeks.map(week => {
+        const barDisplay = week.hubo_quorum === false ? 'Sin quorum' : (week.bar_ganador || '—');
+        return `
         <tr data-week-id="${week.id}" class="${Number(week.id) === Number(weekEditorSelectedId) ? 'table-active' : ''}">
           <td>${escapeHtmlAttr(formatDate(week.fecha_martes))}</td>
-          <td>${escapeHtmlAttr(week.bar_ganador || '—')}</td>
+          <td>${escapeHtmlAttr(barDisplay)}</td>
           <td>${escapeHtmlAttr(week.estado || '—')}</td>
           <td class="text-end">
             <button type="button" class="btn btn-sm btn-outline-info" data-action="select-week" data-week-id="${week.id}">Seleccionar</button>
           </td>
         </tr>
-      `).join('');
+      `;
+      }).join('');
     }
 
     function populateWeekEditorForm(week) {


### PR DESCRIPTION
## Summary
- display "Sin quorum" in the admin history table when a week ended without quorum
- surface the same "Sin quorum" text in the week editor dropdown and table for cancelled weeks
- keep the week editor labels consistent when no bar was selected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6062321788323b4a51b6aa03c4c92